### PR TITLE
[DONE] feat/ingest-gitpull — incremental GitHub pull + commit picker + dev-mode logs

### DIFF
--- a/packages/cli/src/BootCommand.ts
+++ b/packages/cli/src/BootCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { Config } from "@bb/types";
-import { HINTS, getConfigValue } from "@bb/config";
+import { HINTS, getConfigValue, isDevMode } from "@bb/config";
 import { applyInfraDefaults, checkPreflight } from "./bootConfig.ts";
 import {
   DockerComposeError,
@@ -10,7 +10,7 @@ import {
   up,
 } from "./dockerInfra.ts";
 import { ServerStartTimeoutError, ensureServerRunning } from "./serverSpawn.ts";
-import { createSpinner, error, success } from "./output.ts";
+import { createSpinner, error, info, success } from "./output.ts";
 
 export function buildBootCommand(): Command {
   const cmd = new Command("boot");
@@ -22,6 +22,10 @@ async function runBoot(): Promise<void> {
   if (!enforcePreflight()) {
     process.exitCode = 1;
     return;
+  }
+
+  if (isDevMode()) {
+    info(`dev mode: logs → ${process.cwd()}/logs/`);
   }
 
   const defaults = applyInfraDefaults();
@@ -65,6 +69,11 @@ async function runBoot(): Promise<void> {
     });
     if (serverContext.alreadyRunning) {
       serverSpinner.stop(true, `Server already running`);
+      if (serverContext.devModeMismatch === true) {
+        info(
+          "BYTEBELL_DEV=1 set but server is already running. Run `bytebell shutdown && BYTEBELL_DEV=1 bytebell boot` to apply.",
+        );
+      }
     } else {
       serverSpinner.stop(true, `Server started (logs: ${serverContext.logPath ?? "n/a"})`);
     }

--- a/packages/cli/src/CommitSelector.tsx
+++ b/packages/cli/src/CommitSelector.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from "react";
+import type { ReactElement } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+
+/**
+ * Interactive commit picker. Type any character to filter the list (matches
+ * substring against the short hash, full hash, and subject). Up/down (or j/k)
+ * to navigate the filtered view. Enter to choose, Esc to cancel.
+ *
+ * The component is single-select and intentionally narrow — the only thing
+ * the caller gets back is the chosen commit's full hash, or null on cancel.
+ */
+
+export interface CommitSelectorItem {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+
+export interface CommitSelectorResult {
+  picked?: CommitSelectorItem;
+  cancelled?: boolean;
+}
+
+export interface CommitSelectorProps {
+  items: CommitSelectorItem[];
+  title: string | undefined;
+  onDone: (result: CommitSelectorResult) => void;
+}
+
+const MAX_VISIBLE = 12;
+
+export function CommitSelector({ items, title, onDone }: CommitSelectorProps): ReactElement {
+  const { exit } = useApp();
+  const [filter, setFilter] = useState("");
+  const [index, setIndex] = useState(0);
+
+  const filtered = useMemo<CommitSelectorItem[]>(() => {
+    if (filter.length === 0) {
+      return items;
+    }
+    const needle = filter.toLowerCase();
+    return items.filter((item) => {
+      if (item.shortHash.toLowerCase().includes(needle)) {
+        return true;
+      }
+      if (item.hash.toLowerCase().includes(needle)) {
+        return true;
+      }
+      if (item.subject.toLowerCase().includes(needle)) {
+        return true;
+      }
+      if (item.author.toLowerCase().includes(needle)) {
+        return true;
+      }
+      return false;
+    });
+  }, [items, filter]);
+
+  // Keep the cursor inside the filtered range.
+  const boundedIndex = filtered.length === 0 ? 0 : Math.min(index, filtered.length - 1);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      exit();
+      onDone({ cancelled: true });
+      return;
+    }
+    if (key.return) {
+      const chosen = filtered[boundedIndex];
+      exit();
+      onDone(chosen === undefined ? { cancelled: true } : { picked: chosen });
+      return;
+    }
+    if (key.upArrow || (input === "k" && filter.length === 0)) {
+      setIndex(() => (boundedIndex > 0 ? boundedIndex - 1 : Math.max(filtered.length - 1, 0)));
+      return;
+    }
+    if (key.downArrow || (input === "j" && filter.length === 0)) {
+      setIndex(() => (boundedIndex < filtered.length - 1 ? boundedIndex + 1 : 0));
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setFilter((s) => s.slice(0, -1));
+      setIndex(0);
+      return;
+    }
+    if (input.length > 0 && !key.ctrl && !key.meta) {
+      // Type-to-filter: any printable character extends the filter.
+      setFilter((s) => s + input);
+      setIndex(0);
+    }
+  });
+
+  const heading = title ?? "Pick a commit";
+  const visibleStart = clampWindow(boundedIndex, filtered.length, MAX_VISIBLE);
+  const visible = filtered.slice(visibleStart, visibleStart + MAX_VISIBLE);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={1} paddingY={0}>
+      <Box marginBottom={1}>
+        <Text bold>{heading}</Text>
+        <Text dimColor>{`  (${filtered.length}/${items.length})`}</Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text color="cyan">filter: </Text>
+        <Text>{filter.length > 0 ? filter : <Text dimColor>(type to filter)</Text>}</Text>
+      </Box>
+      {filtered.length === 0 ? (
+        <Box>
+          <Text dimColor>No commits match the filter. Backspace to clear.</Text>
+        </Box>
+      ) : (
+        visible.map((item, i) => {
+          const absoluteIndex = visibleStart + i;
+          const cursor = absoluteIndex === boundedIndex;
+          return (
+            <Box key={item.hash}>
+              <Text color={cursor ? "cyan" : "gray"}>{cursor ? "▶ " : "  "}</Text>
+              <Text color={cursor ? "cyan" : "gray"}>{item.shortHash}</Text>
+              <Text dimColor>{` ${item.subject.slice(0, 80)} `}</Text>
+              <Text dimColor>{`(${item.author}, ${formatDate(item.date)})`}</Text>
+            </Box>
+          );
+        })
+      )}
+      <Box marginTop={1}>
+        <Text dimColor>[type to filter] [↑/↓] move [Enter] choose [Backspace] clear [Esc] cancel</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function clampWindow(index: number, total: number, size: number): number {
+  if (total <= size) {
+    return 0;
+  }
+  const halfWindow = Math.floor(size / 2);
+  const start = Math.max(0, Math.min(index - halfWindow, total - size));
+  return start;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/packages/cli/src/Field.tsx
+++ b/packages/cli/src/Field.tsx
@@ -9,10 +9,11 @@ export interface FieldProps {
   onChange: (next: string) => void;
   mask?: boolean;
   error?: string;
+  autoFocus?: boolean;
 }
 
-export function Field({ id, label, value, onChange, mask, error }: FieldProps): ReactElement {
-  const { isFocused } = useFocus({ id });
+export function Field({ id, label, value, onChange, mask, error, autoFocus }: FieldProps): ReactElement {
+  const { isFocused } = useFocus({ id, autoFocus: autoFocus === true });
   const indicator = isFocused ? "▶" : " ";
   const labelProps = isFocused ? { color: "cyan" } : {};
   const masked = mask === true;

--- a/packages/cli/src/LsCommand.ts
+++ b/packages/cli/src/LsCommand.ts
@@ -7,7 +7,9 @@ import { createSpinner, error } from "./output.ts";
 
 interface RepoEntry {
   knowledgeId: string;
-  source: { kind: "github"; repoUrl: string; branch?: string } | { kind: "local"; sourcePath: string };
+  source:
+    | { kind: "github"; repoUrl: string; branch?: string; commitId?: string; commitHashes?: string[] }
+    | { kind: "local"; sourcePath: string };
   state: string;
   createdAt: string;
   updatedAt: string;
@@ -60,12 +62,14 @@ async function runLs(): Promise<void> {
 }
 
 function renderTable(repos: RepoEntry[]): void {
-  const headers = ["ID", "SOURCE", "STATE", "UPDATED", "FILES"];
+  const headers = ["ID", "SOURCE", "STATE", "UPDATED", "HEAD", "COMMITS", "FILES"];
   const rows = repos.map((r) => [
     `${r.knowledgeId.slice(0, 8)}…`,
     formatSource(r.source),
     r.state,
     formatDate(r.updatedAt),
+    formatHead(r.source),
+    formatCommits(r.source),
     String(r.fileCount),
   ]);
   const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i]?.length ?? 0)));
@@ -76,6 +80,23 @@ function renderTable(repos: RepoEntry[]): void {
   for (const row of rows) {
     writeRow(row);
   }
+}
+
+function formatHead(source: RepoEntry["source"]): string {
+  if (source.kind !== "github") {
+    return "-";
+  }
+  if (source.commitId === undefined || source.commitId.length === 0) {
+    return "-";
+  }
+  return source.commitId.slice(0, 8);
+}
+
+function formatCommits(source: RepoEntry["source"]): string {
+  if (source.kind !== "github") {
+    return "-";
+  }
+  return String(source.commitHashes?.length ?? 0);
 }
 
 function formatSource(source: RepoEntry["source"]): string {

--- a/packages/cli/src/PullCommand.ts
+++ b/packages/cli/src/PullCommand.ts
@@ -1,5 +1,3 @@
-import React from "react";
-import { render } from "ink";
 import { Command } from "commander";
 import { Config } from "@bb/types";
 import { getConfigValue } from "@bb/config";
@@ -8,8 +6,7 @@ import { getJson, HttpClientError, postJson } from "./httpClient.ts";
 import { createProgressBar, createSpinner, error, info, type ProgressBar } from "./output.ts";
 import { startLogTailer, type LogTailer } from "./logTailer.ts";
 import { promptRepoSelector } from "./repoSelectorPrompt.ts";
-import { promptCommitSelector } from "./commitSelectorPrompt.ts";
-import { PullModeSelector, type PullModeSelectorResult } from "./PullModeSelector.tsx";
+import { promptPullMode, resolveCommit } from "./pullPrompts.ts";
 
 interface PullResponse {
   knowledgeId: string;
@@ -71,6 +68,7 @@ async function runPull(
     // a different commit per repo would require a sub-prompt per repo which
     // is not worth the complexity for the rare multi-pull case.
     let chosenTargetCommit: string | undefined = options.commit;
+    let activeToken: string | undefined = options.token;
     if (chosenTargetCommit === undefined && picks.length === 1) {
       const only = picks[0];
       if (only !== undefined) {
@@ -80,12 +78,15 @@ async function runPull(
           return;
         }
         if (mode === "specific") {
-          const commit = await promptCommitSelector({ knowledgeId: only.knowledgeId });
-          if (commit === null) {
+          const picked = await resolveCommit(only.knowledgeId, only.label, activeToken);
+          if (picked === null) {
             info("Cancelled.");
             return;
           }
-          chosenTargetCommit = commit.hash;
+          chosenTargetCommit = picked.hash;
+          if (picked.token !== undefined) {
+            activeToken = picked.token;
+          }
         }
       }
     }
@@ -102,8 +103,8 @@ async function runPull(
         if (chosenTargetCommit !== undefined) {
           body["targetCommitHash"] = chosenTargetCommit;
         }
-        if (options.token !== undefined) {
-          body["gitToken"] = options.token;
+        if (activeToken !== undefined) {
+          body["gitToken"] = activeToken;
         }
         const response = await postJson<PullResponse>("/api/v1/github/pull", body);
         return { targetId, response };
@@ -151,25 +152,6 @@ async function pickRepos(): Promise<RepoPick[]> {
     return [];
   }
   return result.picked.map((p) => ({ knowledgeId: p.item.knowledgeId, label: p.item.label }));
-}
-
-async function promptPullMode(repoLabel: string): Promise<"latest" | "specific" | null> {
-  return new Promise<"latest" | "specific" | null>((resolve) => {
-    const onDone = (result: PullModeSelectorResult): void => {
-      if (result.mode !== undefined) {
-        resolve(result.mode);
-        return;
-      }
-      resolve(null);
-    };
-    const { waitUntilExit } = render(
-      React.createElement(PullModeSelector, {
-        repoLabel,
-        onDone,
-      }),
-    );
-    waitUntilExit().catch(() => undefined);
-  });
 }
 
 async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> {

--- a/packages/cli/src/PullCommand.ts
+++ b/packages/cli/src/PullCommand.ts
@@ -1,3 +1,5 @@
+import React from "react";
+import { render } from "ink";
 import { Command } from "commander";
 import { Config } from "@bb/types";
 import { getConfigValue } from "@bb/config";
@@ -6,6 +8,8 @@ import { getJson, HttpClientError, postJson } from "./httpClient.ts";
 import { createProgressBar, createSpinner, error, info, type ProgressBar } from "./output.ts";
 import { startLogTailer, type LogTailer } from "./logTailer.ts";
 import { promptRepoSelector } from "./repoSelectorPrompt.ts";
+import { promptCommitSelector } from "./commitSelectorPrompt.ts";
+import { PullModeSelector, type PullModeSelectorResult } from "./PullModeSelector.tsx";
 
 interface PullResponse {
   knowledgeId: string;
@@ -54,10 +58,36 @@ async function runPull(
     }
 
     // No id supplied → interactive picker, github-only (pull doesn't apply to local repos).
-    const targetIds = knowledgeId !== undefined && knowledgeId.length > 0 ? [knowledgeId] : await pickKnowledgeIds();
-    if (targetIds.length === 0) {
+    const picks =
+      knowledgeId !== undefined && knowledgeId.length > 0 ? [{ knowledgeId, label: knowledgeId }] : await pickRepos();
+    if (picks.length === 0) {
       info("No repo selected.");
       return;
+    }
+
+    // If a single repo was picked and the caller did not pre-supply --commit,
+    // give the user the latest-vs-specific choice. For multi-repo selections
+    // we apply the same target (or HEAD) to every repo — letting the user pick
+    // a different commit per repo would require a sub-prompt per repo which
+    // is not worth the complexity for the rare multi-pull case.
+    let chosenTargetCommit: string | undefined = options.commit;
+    if (chosenTargetCommit === undefined && picks.length === 1) {
+      const only = picks[0];
+      if (only !== undefined) {
+        const mode = await promptPullMode(only.label);
+        if (mode === null) {
+          info("Cancelled.");
+          return;
+        }
+        if (mode === "specific") {
+          const commit = await promptCommitSelector({ knowledgeId: only.knowledgeId });
+          if (commit === null) {
+            info("Cancelled.");
+            return;
+          }
+          chosenTargetCommit = commit.hash;
+        }
+      }
     }
 
     if (options.verbose === true) {
@@ -67,10 +97,10 @@ async function runPull(
     // Enqueue all pulls upfront — BullMQ runs workers concurrently in the
     // server process, so there's no benefit to serialising the HTTP submits.
     const enqueueResults = await Promise.all(
-      targetIds.map(async (targetId) => {
+      picks.map(async ({ knowledgeId: targetId }) => {
         const body: Record<string, string> = { knowledgeId: targetId };
-        if (options.commit !== undefined) {
-          body["latestCommitHash"] = options.commit;
+        if (chosenTargetCommit !== undefined) {
+          body["targetCommitHash"] = chosenTargetCommit;
         }
         if (options.token !== undefined) {
           body["gitToken"] = options.token;
@@ -106,13 +136,40 @@ async function runPull(
   }
 }
 
-async function pickKnowledgeIds(): Promise<string[]> {
+interface RepoPick {
+  knowledgeId: string;
+  label: string;
+}
+
+async function pickRepos(): Promise<RepoPick[]> {
   const result = await promptRepoSelector({
     title: "Select repos to pull",
     filterKind: "github",
     emptyMessage: "No indexed GitHub repos. Run `bytebell index <url>` first.",
   });
-  return result === null ? [] : result.picked.map((p) => p.item.knowledgeId);
+  if (result === null) {
+    return [];
+  }
+  return result.picked.map((p) => ({ knowledgeId: p.item.knowledgeId, label: p.item.label }));
+}
+
+async function promptPullMode(repoLabel: string): Promise<"latest" | "specific" | null> {
+  return new Promise<"latest" | "specific" | null>((resolve) => {
+    const onDone = (result: PullModeSelectorResult): void => {
+      if (result.mode !== undefined) {
+        resolve(result.mode);
+        return;
+      }
+      resolve(null);
+    };
+    const { waitUntilExit } = render(
+      React.createElement(PullModeSelector, {
+        repoLabel,
+        onDone,
+      }),
+    );
+    waitUntilExit().catch(() => undefined);
+  });
 }
 
 async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> {

--- a/packages/cli/src/PullModeSelector.tsx
+++ b/packages/cli/src/PullModeSelector.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import type { ReactElement } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+
+export type PullMode = "latest" | "specific";
+
+export interface PullModeSelectorResult {
+  mode?: PullMode;
+  cancelled?: boolean;
+}
+
+export interface PullModeSelectorProps {
+  repoLabel: string;
+  onDone: (result: PullModeSelectorResult) => void;
+}
+
+interface Choice {
+  mode: PullMode;
+  label: string;
+  hint: string;
+}
+
+const CHOICES: readonly Choice[] = [
+  { mode: "latest", label: "Pull to latest HEAD", hint: "branch tip on origin" },
+  { mode: "specific", label: "Pick a specific commit", hint: "searchable list of recent commits on the branch" },
+];
+
+/**
+ * Two-option chooser shown after a single repo is selected in `bytebell pull`.
+ * The user picks between pulling to the branch's HEAD (default behaviour) or
+ * picking a specific commit from the branch history.
+ */
+export function PullModeSelector({ repoLabel, onDone }: PullModeSelectorProps): ReactElement {
+  const { exit } = useApp();
+  const [index, setIndex] = useState(0);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      exit();
+      onDone({ cancelled: true });
+      return;
+    }
+    if (key.upArrow || input === "k") {
+      setIndex((i) => (i > 0 ? i - 1 : CHOICES.length - 1));
+      return;
+    }
+    if (key.downArrow || input === "j") {
+      setIndex((i) => (i < CHOICES.length - 1 ? i + 1 : 0));
+      return;
+    }
+    if (key.return) {
+      const chosen = CHOICES[index];
+      exit();
+      onDone(chosen === undefined ? { cancelled: true } : { mode: chosen.mode });
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={1} paddingY={0}>
+      <Box marginBottom={1}>
+        <Text bold>How should we pull </Text>
+        <Text bold color="cyan">
+          {repoLabel}
+        </Text>
+        <Text bold>?</Text>
+      </Box>
+      {CHOICES.map((choice, i) => (
+        <Box key={choice.mode}>
+          <Text color={i === index ? "cyan" : "gray"}>{i === index ? "▶ " : "  "}</Text>
+          <Text color={i === index ? "cyan" : "gray"}>{choice.label}</Text>
+          <Text dimColor>{` — ${choice.hint}`}</Text>
+        </Box>
+      ))}
+      <Box marginTop={1}>
+        <Text dimColor>[↑/↓ or j/k] move [Enter] choose [Esc] cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/TokenPrompt.tsx
+++ b/packages/cli/src/TokenPrompt.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import type { ReactElement } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import { Field } from "./Field.tsx";
+
+/**
+ * Single-field masked prompt for a GitHub PAT, shown when the commits
+ * endpoint returns 404 for a private repo. Enter submits, Esc cancels.
+ *
+ * Intentionally narrower than SetupForm — one field, no validation beyond
+ * non-empty, no config persistence. The collected token stays in-memory
+ * for the current CLI invocation only.
+ */
+
+export interface TokenPromptResult {
+  token?: string;
+  cancelled?: boolean;
+}
+
+export interface TokenPromptProps {
+  repoLabel: string;
+  message?: string;
+  onDone: (result: TokenPromptResult) => void;
+}
+
+export function TokenPrompt({ repoLabel, message, onDone }: TokenPromptProps): ReactElement {
+  const { exit } = useApp();
+  const [value, setValue] = useState("");
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      exit();
+      onDone({ cancelled: true });
+      return;
+    }
+    if (key.return && value.length > 0) {
+      exit();
+      onDone({ token: value });
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={1} paddingY={0}>
+      <Box marginBottom={1}>
+        <Text bold>GitHub token required for {repoLabel}</Text>
+      </Box>
+      {message !== undefined && message.length > 0 && (
+        <Box marginBottom={1}>
+          <Text dimColor>{message}</Text>
+        </Box>
+      )}
+      <Field id="token" label="GitHub PAT" value={value} onChange={setValue} mask autoFocus />
+      <Box marginTop={1}>
+        <Text dimColor>[Enter] submit [Esc] cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/commitSelectorPrompt.ts
+++ b/packages/cli/src/commitSelectorPrompt.ts
@@ -1,0 +1,59 @@
+import React from "react";
+import { render } from "ink";
+import { getJson } from "./httpClient.ts";
+import { CommitSelector, type CommitSelectorItem, type CommitSelectorResult } from "./CommitSelector.tsx";
+
+interface CommitsResponse {
+  knowledgeId: string;
+  branch: string;
+  commits: Array<{
+    hash: string;
+    shortHash: string;
+    subject: string;
+    author: string;
+    date: string;
+  }>;
+}
+
+export interface CommitPromptOptions {
+  knowledgeId: string;
+  limit?: number;
+  title?: string;
+}
+
+/**
+ * Fetches commit history for a knowledge via `/api/v1/github/:id/commits`
+ * and renders the searchable picker. Returns the chosen commit (full hash)
+ * or `null` on cancel.
+ */
+export async function promptCommitSelector(opts: CommitPromptOptions): Promise<CommitSelectorItem | null> {
+  const url = `/api/v1/github/${encodeURIComponent(opts.knowledgeId)}/commits?limit=${opts.limit ?? 200}`;
+  const response = await getJson<CommitsResponse>(url);
+  if (response.commits.length === 0) {
+    return null;
+  }
+  const items: CommitSelectorItem[] = response.commits.map((c) => ({
+    hash: c.hash,
+    shortHash: c.shortHash,
+    subject: c.subject,
+    author: c.author,
+    date: c.date,
+  }));
+  return await renderPicker(items, opts.title ?? `Pick a commit (origin/${response.branch})`);
+}
+
+async function renderPicker(items: CommitSelectorItem[], title: string): Promise<CommitSelectorItem | null> {
+  return new Promise<CommitSelectorItem | null>((resolve) => {
+    const onDone = (result: CommitSelectorResult): void => {
+      resolve(result.picked ?? null);
+    };
+    const { waitUntilExit } = render(
+      React.createElement(CommitSelector, {
+        items,
+        title,
+        onDone,
+      }),
+    );
+    waitUntilExit().catch(() => undefined);
+  });
+}

--- a/packages/cli/src/commitSelectorPrompt.ts
+++ b/packages/cli/src/commitSelectorPrompt.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "ink";
-import { getJson } from "./httpClient.ts";
+import { getJson, HttpClientError } from "./httpClient.ts";
 import { CommitSelector, type CommitSelectorItem, type CommitSelectorResult } from "./CommitSelector.tsx";
 
 interface CommitsResponse {
@@ -19,19 +19,48 @@ export interface CommitPromptOptions {
   knowledgeId: string;
   limit?: number;
   title?: string;
+  gitToken?: string;
 }
+
+export type CommitPromptResult =
+  | { kind: "picked"; commit: CommitSelectorItem }
+  | { kind: "cancelled" }
+  | { kind: "needs_token" }
+  | { kind: "unauthorized" }
+  | { kind: "empty" };
 
 /**
  * Fetches commit history for a knowledge via `/api/v1/github/:id/commits`
- * and renders the searchable picker. Returns the chosen commit (full hash)
- * or `null` on cancel.
+ * and renders the searchable picker. Returns a discriminated result so the
+ * caller can distinguish "user cancelled" from "private repo, prompt for
+ * token" from "supplied token was rejected".
  */
-export async function promptCommitSelector(opts: CommitPromptOptions): Promise<CommitSelectorItem | null> {
+export async function promptCommitSelector(opts: CommitPromptOptions): Promise<CommitPromptResult> {
   const url = `/api/v1/github/${encodeURIComponent(opts.knowledgeId)}/commits?limit=${opts.limit ?? 200}`;
-  const response = await getJson<CommitsResponse>(url);
-  if (response.commits.length === 0) {
-    return null;
+  const headers: Record<string, string> = {};
+  if (opts.gitToken !== undefined && opts.gitToken.length > 0) {
+    headers["Authorization"] = `Bearer ${opts.gitToken}`;
   }
+
+  let response: CommitsResponse;
+  try {
+    response = await getJson<CommitsResponse>(url, { headers });
+  } catch (cause: unknown) {
+    if (cause instanceof HttpClientError) {
+      if (cause.status === 404) {
+        return { kind: "needs_token" };
+      }
+      if (cause.status === 401) {
+        return { kind: "unauthorized" };
+      }
+    }
+    throw cause;
+  }
+
+  if (response.commits.length === 0) {
+    return { kind: "empty" };
+  }
+
   const items: CommitSelectorItem[] = response.commits.map((c) => ({
     hash: c.hash,
     shortHash: c.shortHash,
@@ -39,7 +68,11 @@ export async function promptCommitSelector(opts: CommitPromptOptions): Promise<C
     author: c.author,
     date: c.date,
   }));
-  return await renderPicker(items, opts.title ?? `Pick a commit (origin/${response.branch})`);
+  const picked = await renderPicker(items, opts.title ?? `Pick a commit (origin/${response.branch})`);
+  if (picked === null) {
+    return { kind: "cancelled" };
+  }
+  return { kind: "picked", commit: picked };
 }
 
 async function renderPicker(items: CommitSelectorItem[], title: string): Promise<CommitSelectorItem | null> {

--- a/packages/cli/src/httpClient.ts
+++ b/packages/cli/src/httpClient.ts
@@ -37,12 +37,17 @@ export async function postJson<T>(routePath: string, body: object): Promise<T> {
   return parseResponse<T>(res);
 }
 
-export async function getJson<T>(routePath: string): Promise<T> {
+export interface GetJsonInit {
+  headers?: Record<string, string>;
+}
+
+export async function getJson<T>(routePath: string, init?: GetJsonInit): Promise<T> {
   const url = `${baseUrl()}${routePath}`;
   let res: Response;
   try {
     res = await fetch(url, {
       method: "GET",
+      ...(init?.headers !== undefined ? { headers: init.headers } : {}),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   } catch (cause: unknown) {

--- a/packages/cli/src/pullPrompts.ts
+++ b/packages/cli/src/pullPrompts.ts
@@ -1,0 +1,103 @@
+import React from "react";
+import { render } from "ink";
+import { error, info } from "./output.ts";
+import { promptCommitSelector, type CommitPromptResult } from "./commitSelectorPrompt.ts";
+import { PullModeSelector, type PullModeSelectorResult } from "./PullModeSelector.tsx";
+import { TokenPrompt, type TokenPromptResult } from "./TokenPrompt.tsx";
+
+export interface ResolvedCommit {
+  hash: string;
+  token: string | undefined;
+}
+
+/**
+ * Renders the commit picker, transparently handling private-repo 404s by
+ * prompting for a GitHub PAT and retrying once. Returns the chosen commit
+ * (plus the token if one was collected) or `null` on cancel / empty / repeated
+ * auth failure.
+ */
+export async function resolveCommit(
+  knowledgeId: string,
+  repoLabel: string,
+  existingToken: string | undefined,
+): Promise<ResolvedCommit | null> {
+  let token = existingToken;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const opts: Parameters<typeof promptCommitSelector>[0] = { knowledgeId };
+    if (token !== undefined) {
+      opts.gitToken = token;
+    }
+    const result: CommitPromptResult = await promptCommitSelector(opts);
+
+    if (result.kind === "picked") {
+      return { hash: result.commit.hash, token };
+    }
+    if (result.kind === "cancelled") {
+      return null;
+    }
+    if (result.kind === "empty") {
+      info(`No commits returned for ${repoLabel}.`);
+      return null;
+    }
+    if (result.kind === "needs_token" || result.kind === "unauthorized") {
+      if (attempt === 1) {
+        error(
+          result.kind === "unauthorized"
+            ? `GitHub rejected the token for ${repoLabel}.`
+            : `Still no access to ${repoLabel} after supplying a token.`,
+        );
+        return null;
+      }
+      const promptMessage =
+        result.kind === "unauthorized"
+          ? "The previous token was rejected. Try a different PAT."
+          : "This repo looks private. Paste a GitHub PAT with `repo` scope.";
+      const tokenResult = await promptForToken(repoLabel, promptMessage);
+      if (tokenResult === null) {
+        info("Cancelled.");
+        return null;
+      }
+      token = tokenResult;
+    }
+  }
+  return null;
+}
+
+async function promptForToken(repoLabel: string, message: string): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    const onDone = (result: TokenPromptResult): void => {
+      if (result.token !== undefined && result.token.length > 0) {
+        resolve(result.token);
+        return;
+      }
+      resolve(null);
+    };
+    const { waitUntilExit } = render(
+      React.createElement(TokenPrompt, {
+        repoLabel,
+        message,
+        onDone,
+      }),
+    );
+    waitUntilExit().catch(() => undefined);
+  });
+}
+
+export async function promptPullMode(repoLabel: string): Promise<"latest" | "specific" | null> {
+  return new Promise<"latest" | "specific" | null>((resolve) => {
+    const onDone = (result: PullModeSelectorResult): void => {
+      if (result.mode !== undefined) {
+        resolve(result.mode);
+        return;
+      }
+      resolve(null);
+    };
+    const { waitUntilExit } = render(
+      React.createElement(PullModeSelector, {
+        repoLabel,
+        onDone,
+      }),
+    );
+    waitUntilExit().catch(() => undefined);
+  });
+}

--- a/packages/cli/src/repoSelectorPrompt.ts
+++ b/packages/cli/src/repoSelectorPrompt.ts
@@ -26,7 +26,9 @@ import {
 
 export interface RepoListEntry {
   knowledgeId: string;
-  source: { kind: "github"; repoUrl: string; branch?: string } | { kind: "local"; sourcePath: string };
+  source:
+    | { kind: "github"; repoUrl: string; branch?: string; commitId?: string; commitHashes?: string[] }
+    | { kind: "local"; sourcePath: string };
   state: string;
   createdAt: string;
   updatedAt: string;
@@ -96,8 +98,21 @@ function toSelectorItem(repo: RepoListEntry): RepoSelectorItem {
   return {
     knowledgeId: repo.knowledgeId,
     label: formatSourceLabel(repo.source),
-    detail: `${repo.state}  ${repo.knowledgeId.slice(0, 8)}…  ${repo.fileCount} files`,
+    detail: formatDetail(repo),
   };
+}
+
+function formatDetail(repo: RepoListEntry): string {
+  const idChunk = `${repo.knowledgeId.slice(0, 8)}…`;
+  if (repo.source.kind !== "github") {
+    return `${repo.state}  ${idChunk}  ${repo.fileCount} files`;
+  }
+  const head =
+    repo.source.commitId !== undefined && repo.source.commitId.length > 0
+      ? `head=${repo.source.commitId.slice(0, 8)}`
+      : "head=-";
+  const commits = `${repo.source.commitHashes?.length ?? 0} commits`;
+  return `${repo.state}  ${idChunk}  ${head}  ${commits}  ${repo.fileCount} files`;
 }
 
 function formatSourceLabel(source: RepoListEntry["source"]): string {

--- a/packages/cli/src/serverSpawn.ts
+++ b/packages/cli/src/serverSpawn.ts
@@ -3,7 +3,8 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Config } from "@bb/types";
-import { getBytebellHome, getConfigValue } from "@bb/config";
+import { getConfigValue, isDevMode } from "@bb/config";
+import { getLogsDir } from "@bb/logger";
 
 const HEALTH_TIMEOUT_MS = 500;
 const SPAWN_POLL_INTERVAL_MS = 200;
@@ -22,9 +23,14 @@ export class ServerStartTimeoutError extends Error {
 export async function ensureServerRunning(onProgress?: (line: string) => void): Promise<{
   alreadyRunning: boolean;
   logPath?: string;
+  devModeMismatch?: boolean;
 }> {
   if (await isHealthy()) {
-    return { alreadyRunning: true };
+    // The running server was spawned in whatever env existed at boot. We
+    // can't introspect its environment from here, but if the CURRENT process
+    // has BYTEBELL_DEV=1 set we surface a mismatch hint — without it, users
+    // assume the running server picked up the toggle when it hasn't.
+    return { alreadyRunning: true, devModeMismatch: isDevMode() };
   }
   const logPath = await spawnDetached();
   for (let i = 0; i < SPAWN_MAX_POLLS; i++) {
@@ -52,7 +58,7 @@ async function isHealthy(): Promise<boolean> {
 }
 
 async function spawnDetached(): Promise<string> {
-  const logsDir = path.join(getBytebellHome(), "logs");
+  const logsDir = getLogsDir();
   await mkdir(logsDir, { recursive: true, mode: 0o700 });
   const today = new Date().toISOString().slice(0, 10);
   const logPath = path.join(logsDir, `server-${today}.log`);

--- a/packages/config/src/context.md
+++ b/packages/config/src/context.md
@@ -48,3 +48,11 @@ seam so that `loader.ts` and `writer.ts` never have to import each other.
 - File mode `0o600` on `config.json`; directory mode `0o700` on `~/.bytebell/`.
 - `loadConfig` always calls `ensureBytebellHome` first — never reads a missing
   file.
+- **`org_id` is locked to `"local"` in OSS builds.** The Zod schema for
+  `org_id` defaults to `"local"` and `.refine`s that no other value is
+  accepted — a hand-edited `config.json` with any other `org_id` makes
+  `loadConfig()` throw and the server refuses to boot. `writeField`
+  throws on `Config.OrgId`, and `keyMap.ts` in `@bb/cli` deliberately
+  has no entry for it so `bytebell set org_id …` is rejected at the CLI.
+  Per-job org overrides for downstream enterprise builds live on the
+  payload (`GithubIndexPayload.orgId?`), not in config.json.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,4 +6,4 @@ export type { ConfigCompletenessResult } from "./loader.ts";
 
 export { setConfigValue, ensureBytebellHome } from "./writer.ts";
 
-export { getBytebellHome, getConfigPath, __setBytebellHomeForTests } from "./paths.ts";
+export { getBytebellHome, getConfigPath, isDevMode, __setBytebellHomeForTests } from "./paths.ts";

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -29,3 +29,14 @@ export function __setBytebellHomeForTests(home: string | null): void {
   testHomeOverride = home;
   __notifyConfigChanged();
 }
+
+/**
+ * Dev-mode toggle. Enabled by `BYTEBELL_DEV=1` on the shell session.
+ *
+ * Narrow purpose: redirect log output to the working directory so contributors
+ * can tail logs without cd-ing to ~/.bytebell. Does NOT bypass the Rule of Env
+ * Vars — no infra URI, credential, or persisted setting is sourced here.
+ */
+export function isDevMode(): boolean {
+  return process.env["BYTEBELL_DEV"] === "1";
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -38,6 +38,16 @@ export const configSchema = z
     "condense.context.limit": z.number().int().positive().default(12000),
     "condense.prompt.overhead": z.number().int().nonnegative().default(1500),
     "small.file.dedup.threshold": z.number().int().positive().default(3),
+    "big.file.line.threshold": z.number().int().positive().default(1200),
+    "skip.decision.enabled": z.boolean().default(true),
+    "skip.decision.max.chars.for.llm": z.number().int().positive().default(20000),
+    "skip.decision.cache.path": z.string().default(""),
+    org_id: z
+      .string()
+      .default("local")
+      .refine((v) => v === "local", {
+        message: "org_id must be 'local' — OSS builds are single-tenant and cannot run with any other org_id",
+      }),
   })
   .strict();
 
@@ -70,6 +80,11 @@ export type ConfigValueMap = {
   [Config.CondenseContextLimit]: number;
   [Config.CondensePromptOverhead]: number;
   [Config.SmallFileDedupThreshold]: number;
+  [Config.BigFileLineThreshold]: number;
+  [Config.OrgId]: string;
+  [Config.SkipDecisionEnabled]: boolean;
+  [Config.SkipDecisionMaxCharsForLlm]: number;
+  [Config.SkipDecisionCachePath]: string;
 };
 
 export type ConfigValue<K extends Config> = ConfigValueMap[K];
@@ -108,6 +123,11 @@ export const HINTS: Readonly<Record<Config, string>> = {
   [Config.CondenseContextLimit]: "bytebell set condense.context.limit <n>",
   [Config.CondensePromptOverhead]: "bytebell set condense.prompt.overhead <n>",
   [Config.SmallFileDedupThreshold]: "bytebell set small.file.dedup.threshold <n>",
+  [Config.BigFileLineThreshold]: "bytebell set big.file.line.threshold <n>",
+  [Config.OrgId]: "org_id is fixed to 'local' in OSS builds and cannot be changed",
+  [Config.SkipDecisionEnabled]: "bytebell set skip.decision.enabled <true|false>",
+  [Config.SkipDecisionMaxCharsForLlm]: "bytebell set skip.decision.max.chars.for.llm <n>",
+  [Config.SkipDecisionCachePath]: "bytebell set skip.decision.cache.path <absolute-path>",
 };
 
 export function readField<K extends Config>(cfg: BytebellConfig, key: K): ConfigValue<K> {
@@ -160,6 +180,16 @@ export function readField<K extends Config>(cfg: BytebellConfig, key: K): Config
       return cfg["condense.prompt.overhead"] as ConfigValue<K>;
     case Config.SmallFileDedupThreshold:
       return cfg["small.file.dedup.threshold"] as ConfigValue<K>;
+    case Config.BigFileLineThreshold:
+      return cfg["big.file.line.threshold"] as ConfigValue<K>;
+    case Config.OrgId:
+      return cfg.org_id as ConfigValue<K>;
+    case Config.SkipDecisionEnabled:
+      return cfg["skip.decision.enabled"] as ConfigValue<K>;
+    case Config.SkipDecisionMaxCharsForLlm:
+      return cfg["skip.decision.max.chars.for.llm"] as ConfigValue<K>;
+    case Config.SkipDecisionCachePath:
+      return cfg["skip.decision.cache.path"] as ConfigValue<K>;
   }
 }
 
@@ -213,5 +243,15 @@ export function writeField<K extends Config>(cfg: BytebellConfig, key: K, value:
       return { ...cfg, "condense.prompt.overhead": value as number };
     case Config.SmallFileDedupThreshold:
       return { ...cfg, "small.file.dedup.threshold": value as number };
+    case Config.BigFileLineThreshold:
+      return { ...cfg, "big.file.line.threshold": value as number };
+    case Config.OrgId:
+      throw new Error("org_id is fixed to 'local' in OSS builds and cannot be set");
+    case Config.SkipDecisionEnabled:
+      return { ...cfg, "skip.decision.enabled": value as boolean };
+    case Config.SkipDecisionMaxCharsForLlm:
+      return { ...cfg, "skip.decision.max.chars.for.llm": value as number };
+    case Config.SkipDecisionCachePath:
+      return { ...cfg, "skip.decision.cache.path": value as string };
   }
 }

--- a/packages/ingest-github/src/context.md
+++ b/packages/ingest-github/src/context.md
@@ -13,12 +13,14 @@ Domain (composes infra: `@bb/config`, `@bb/llm`, `@bb/mongo`, `@bb/neo4j`,
 
 - **[index.ts](index.ts)** — public surface. `registerGithubWorkers`,
   `registerLocalIngestWorker`, `createFlatFolderStrategy`,
-  `createLlmFileAnalyzer`, plus the strategy / pipeline type re-exports and
-  the legacy `parseGithubRepo` / `fetchLatestCommitHash` exports (kept for
-  the pull plan). The two `register*` factories compose the runner against
-  the flat-folder strategy and register BullMQ handlers. `GithubPull` is
-  registered but the handler throws `IngestError("…being migrated…")` — the
-  HTTP route mirrors this at 503.
+  `createLlmFileAnalyzer`, `createDiskSourceReader`, the
+  `SourceReader` / `ArchiveSink` / `SourceFactory` port types, plus
+  `parseGithubRepo` / `fetchLatestCommitHash` (kept for the pull plan).
+  `registerGithubWorkers` accepts one optional `sourceFactory` injection
+  parameter so downstream consumers can replace the default disk-based
+  clone-and-read; the open-source binary always leaves it undefined. for the
+  seam. `GithubPull` is registered but the handler throws
+  `IngestError("…being migrated…")` — the HTTP route mirrors this at 503.
 - **[githubApi.ts](githubApi.ts)** — `parseGithubRepo(repoUrl)` and
   `fetchLatestCommitHash(owner, repo, branch, gitToken?)`. **Pull-only
   utility**; revisit in the pull plan. Kept in place rather than deleted so

--- a/packages/ingest-github/src/githubApi.ts
+++ b/packages/ingest-github/src/githubApi.ts
@@ -72,3 +72,143 @@ export async function fetchLatestCommitHash(
   const sha = body.commit?.sha;
   return typeof sha === "string" && sha.length > 0 ? sha : null;
 }
+
+export interface CommitEntry {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+
+export type FetchCommitsResult =
+  | { status: "ok"; commits: CommitEntry[] }
+  | { status: "not_found" }
+  | { status: "unauthorized" }
+  | { status: "rate_limited" }
+  | { status: "error"; message: string };
+
+const COMMITS_PAGE_SIZE = 100;
+
+interface GithubCommitPayload {
+  sha?: unknown;
+  commit?: {
+    message?: unknown;
+    author?: { name?: unknown; date?: unknown } | null;
+    committer?: { name?: unknown; date?: unknown } | null;
+  };
+}
+
+/**
+ * Fetches up to `limit` commits on `branch` via GitHub's REST API. The
+ * server route uses this in place of `git log` against a shallow local
+ * clone — the picker should not depend on clone state.
+ *
+ * Paginates over `/commits` (capped at 100 per page) until either `limit`
+ * is reached or the upstream returns a short page. Unauthenticated calls
+ * work for public repos; private repos answer 404 until a token is
+ * supplied, at which point the CLI re-requests with `Authorization`.
+ */
+export async function fetchRecentCommits(
+  repoUrl: string,
+  branch: string,
+  limit: number,
+  gitToken?: string,
+): Promise<FetchCommitsResult> {
+  const parsed = parseGithubRepo(repoUrl);
+  if (parsed === null) {
+    return { status: "error", message: `unparseable github url: ${repoUrl}` };
+  }
+  if (limit <= 0) {
+    return { status: "ok", commits: [] };
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": USER_AGENT,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (gitToken !== undefined && gitToken.length > 0) {
+    headers["Authorization"] = `Bearer ${gitToken}`;
+  }
+
+  const collected: CommitEntry[] = [];
+  let page = 1;
+  while (collected.length < limit) {
+    const remaining = limit - collected.length;
+    const perPage = Math.min(COMMITS_PAGE_SIZE, remaining);
+    const url =
+      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/commits` +
+      `?sha=${encodeURIComponent(branch)}&per_page=${perPage}&page=${page}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (cause: unknown) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      return { status: "error", message: `github fetch failed: ${msg}` };
+    }
+
+    if (response.status === 404) {
+      return { status: "not_found" };
+    }
+    if (response.status === 401) {
+      return { status: "unauthorized" };
+    }
+    if (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0") {
+      return { status: "rate_limited" };
+    }
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      return { status: "error", message: `github ${response.status}: ${body.slice(0, 200)}` };
+    }
+
+    const payload = (await response.json()) as GithubCommitPayload[];
+    if (!Array.isArray(payload) || payload.length === 0) {
+      break;
+    }
+    for (const item of payload) {
+      const entry = toCommitEntry(item);
+      if (entry !== null) {
+        collected.push(entry);
+        if (collected.length >= limit) {
+          break;
+        }
+      }
+    }
+    if (payload.length < perPage) {
+      break;
+    }
+    page += 1;
+  }
+
+  return { status: "ok", commits: collected };
+}
+
+function toCommitEntry(raw: GithubCommitPayload): CommitEntry | null {
+  const sha = raw.sha;
+  if (typeof sha !== "string" || sha.length === 0) {
+    return null;
+  }
+  const message = typeof raw.commit?.message === "string" ? raw.commit.message : "";
+  const subjectLine = message.split("\n", 1)[0] ?? "";
+  const authorName =
+    typeof raw.commit?.author?.name === "string"
+      ? raw.commit.author.name
+      : typeof raw.commit?.committer?.name === "string"
+        ? raw.commit.committer.name
+        : "";
+  const authorDate =
+    typeof raw.commit?.author?.date === "string"
+      ? raw.commit.author.date
+      : typeof raw.commit?.committer?.date === "string"
+        ? raw.commit.committer.date
+        : "";
+  return {
+    hash: sha,
+    shortHash: sha.slice(0, 7),
+    subject: subjectLine,
+    author: authorName,
+    date: authorDate,
+  };
+}

--- a/packages/ingest-github/src/index.ts
+++ b/packages/ingest-github/src/index.ts
@@ -1,9 +1,8 @@
 import { JobType } from "@bb/types";
 import { registerWorker } from "@bb/queue";
-import { IngestError } from "@bb/errors";
-import { logger } from "@bb/logger";
 import { createPipelineRunner } from "./pipeline/run.ts";
 import { reposRoot } from "./pipeline/paths.ts";
+import { runPull } from "./pipeline/pull.ts";
 import { createGithubIngestHandler, createLocalIngestHandler } from "./handlers/ingest-job.ts";
 import { createFlatFolderStrategy } from "./strategies/flat-folder/index.ts";
 import { createLlmFileAnalyzer } from "./adapters/llm-file-analyzer.ts";
@@ -39,13 +38,7 @@ function buildRunner(sourceFactory: SourceFactory | undefined): ReturnType<typeo
 export function registerGithubWorkers(deps: RegisterGithubWorkersDeps = {}): void {
   const runner = buildRunner(deps.sourceFactory);
   registerWorker(JobType.GithubIndex, createGithubIngestHandler({ runner }));
-  registerWorker(JobType.GithubPull, async (msg): Promise<void> => {
-    logger.warn(`github_pull migrating to flat-folder — job ${msg.id} parked`);
-    throw new IngestError(
-      msg.knowledgeId,
-      "github_pull is being migrated to the flat-folder strategy; please re-index for now",
-    );
-  });
+  registerWorker(JobType.GithubPull, runPull);
 }
 
 export function registerLocalIngestWorker(): void {

--- a/packages/ingest-github/src/index.ts
+++ b/packages/ingest-github/src/index.ts
@@ -65,5 +65,5 @@ export type {
   SourceFactoryResult,
 } from "./types/pipeline.ts";
 export type { CondensedFileAnalysis } from "./types/condensed-file-analysis.ts";
-export { fetchLatestCommitHash, parseGithubRepo } from "./githubApi.ts";
-export type { ParsedRepo } from "./githubApi.ts";
+export { fetchLatestCommitHash, fetchRecentCommits, parseGithubRepo } from "./githubApi.ts";
+export type { CommitEntry, FetchCommitsResult, ParsedRepo } from "./githubApi.ts";

--- a/packages/ingest-github/src/index.ts
+++ b/packages/ingest-github/src/index.ts
@@ -11,18 +11,33 @@ import {
   COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
   buildFileAnalysisUserPrompt,
 } from "./strategies/flat-folder/prompts/file-analysis.ts";
+import type { SourceFactory } from "./types/pipeline.ts";
 
-function buildSharedRunner(): ReturnType<typeof createPipelineRunner> {
+/**
+ * Optional dependencies for the GitHub workers. Today only one field is
+ * exposed: a source factory. Documented in `docs/extension-points.md`.
+ * The open-source binary leaves this undefined — the default disk reader
+ * runs unchanged.
+ */
+export interface RegisterGithubWorkersDeps {
+  sourceFactory?: SourceFactory;
+}
+
+function buildRunner(sourceFactory: SourceFactory | undefined): ReturnType<typeof createPipelineRunner> {
   const fileAnalyzer = createLlmFileAnalyzer({
     buildSystemPrompt: () => COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
     buildUserPrompt: buildFileAnalysisUserPrompt,
   });
   const strategy = createFlatFolderStrategy({ fileAnalyzer });
-  return createPipelineRunner({ reposRootDir: reposRoot(), strategy });
+  const runnerDeps: Parameters<typeof createPipelineRunner>[0] = { reposRootDir: reposRoot(), strategy };
+  if (sourceFactory !== undefined) {
+    runnerDeps.sourceFactory = sourceFactory;
+  }
+  return createPipelineRunner(runnerDeps);
 }
 
-export function registerGithubWorkers(): void {
-  const runner = buildSharedRunner();
+export function registerGithubWorkers(deps: RegisterGithubWorkersDeps = {}): void {
+  const runner = buildRunner(deps.sourceFactory);
   registerWorker(JobType.GithubIndex, createGithubIngestHandler({ runner }));
   registerWorker(JobType.GithubPull, async (msg): Promise<void> => {
     logger.warn(`github_pull migrating to flat-folder — job ${msg.id} parked`);
@@ -34,14 +49,28 @@ export function registerGithubWorkers(): void {
 }
 
 export function registerLocalIngestWorker(): void {
-  const runner = buildSharedRunner();
+  const runner = buildRunner(undefined);
   registerWorker(JobType.LocalIngest, createLocalIngestHandler({ runner }));
 }
 
 export { createFlatFolderStrategy } from "./strategies/flat-folder/index.ts";
 export { createLlmFileAnalyzer } from "./adapters/llm-file-analyzer.ts";
+export { createDiskSourceReader } from "./pipeline/disk-source-reader.ts";
 export type { IngestStrategy, StrategyInput, StrategyResult, StrategyContext } from "./types/strategy.ts";
-export type { FileAnalyzer, AnalyzedFileResult } from "./types/pipeline.ts";
+export type {
+  FileAnalyzer,
+  AnalyzedFileResult,
+  ScanEntry,
+  ScannedFile,
+  OversizedFile,
+  ScanDeps,
+  SourceReader,
+  ArchiveSink,
+  ArchiveSinkInput,
+  SourceFactory,
+  SourceFactoryInput,
+  SourceFactoryResult,
+} from "./types/pipeline.ts";
 export type { CondensedFileAnalysis } from "./types/condensed-file-analysis.ts";
 export { fetchLatestCommitHash, parseGithubRepo } from "./githubApi.ts";
 export type { ParsedRepo } from "./githubApi.ts";

--- a/packages/ingest-github/src/pipeline/affected-folders.ts
+++ b/packages/ingest-github/src/pipeline/affected-folders.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import type { DiffResult } from "./git-diff.ts";
+
+/**
+ * Compute the set of direct-parent folders affected by a diff. The set
+ * includes the parent of every added, modified, deleted, and renamed path
+ * (both old and new). Returns POSIX-style folder paths; the repository root
+ * is represented as the empty string.
+ */
+export function affectedFoldersFromDiff(diff: DiffResult): Set<string> {
+  const folders = new Set<string>();
+  for (const p of diff.added) {
+    folders.add(directFolderOf(p));
+  }
+  for (const p of diff.modified) {
+    folders.add(directFolderOf(p));
+  }
+  for (const p of diff.deleted) {
+    folders.add(directFolderOf(p));
+  }
+  for (const r of diff.renamed) {
+    folders.add(directFolderOf(r.oldPath));
+    folders.add(directFolderOf(r.newPath));
+  }
+  return folders;
+}
+
+export function directFolderOf(relativePath: string): string {
+  const dir = path.posix.dirname(relativePath.split(path.sep).join("/"));
+  if (dir === "." || dir === "/") {
+    return "";
+  }
+  return dir;
+}

--- a/packages/ingest-github/src/pipeline/context.md
+++ b/packages/ingest-github/src/pipeline/context.md
@@ -29,6 +29,10 @@ Domain (sub-folder of `@bb/ingest-github`).
   `skip-decisions/context.md`. Active when `Config.SkipDecisionEnabled =
 true` (default). Consumed by `scan.ts` via the optional `skipDecider`
   dep; built by `classifyAndAnalyseSmall` if not injected.
+- `disk-source-reader.ts` — `createDiskSourceReader({ repoDir, commitHash })`
+  returns a `SourceReader` that wraps `scanRepository` + `node:fs.readFile`.
+  The default reader the open-source binary always uses, unless the caller
+  injects a `sourceFactory` (see `docs/extension-points.md`).
 - `scan.ts` — async generator `scanRepository(rootDir, deps?)` yielding `ScanEntry`
   (`kind: "file"` or `kind: "oversized"`). A file is `oversized` when its
   byte size exceeds `Config.AbsoluteFileSizeCap` (skipped before read) or
@@ -36,10 +40,17 @@ true` (default). Consumed by `scan.ts` via the optional `skipDecider`
   enters the big-file phase). Both thresholds are config-driven — no
   magic numbers in this file. `readScannedFile` re-reads a file by
   absolute path for the big-file phase which streams content lazily.
-- `run.ts` — `createPipelineRunner({ reposRootDir, strategy })` builds an
-  `IngestRunnerDeps` that dispatches on payload shape: GitHub payloads go
-  through clone + branch resolve + strategy execute + commit persistence;
-  local payloads skip the clone. `resolveOrgId(payload)` returns
+- `run.ts` — `createPipelineRunner({ reposRootDir, strategy, sourceFactory? })`
+  builds an `IngestRunnerDeps`. GitHub payloads run: branch resolve,
+  source-reader construction, strategy execute, commit persistence. Local
+  payloads skip the clone. The source reader is chosen by the optional
+  `sourceFactory` parameter: if undefined (open-source default), the
+  runner builds a `DiskSourceReader` via `source.ts.syncRepository` +
+  `readHeadCommitHash`. If a factory is supplied, the runner calls it
+  with `{ knowledgeId, payload, branch }` and uses the returned reader +
+  commit hash; the local clone is skipped. The factory may also return an
+  `archiveSink` which the strategy then threads through to its
+  analyse phase. `resolveOrgId(payload)` returns
   `payload.orgId ?? getConfigValue(Config.OrgId)` — the only place orgId
   is resolved. State transitions (`CREATED → QUEUED → INGESTED → …`) are
   persisted to Mongo + Neo4j via `transitionState`, and

--- a/packages/ingest-github/src/pipeline/disk-source-reader.ts
+++ b/packages/ingest-github/src/pipeline/disk-source-reader.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import type { ScanDeps, ScanEntry, SourceReader } from "src/types/pipeline.ts";
+import { scanRepository } from "./scan.ts";
+
+export interface DiskSourceReaderDeps {
+  repoDir: string;
+  commitHash: string;
+}
+
+export function createDiskSourceReader(deps: DiskSourceReaderDeps): SourceReader {
+  return {
+    commitHash: deps.commitHash,
+    localRepoDir: deps.repoDir,
+    scan(scanDeps?: ScanDeps): AsyncGenerator<ScanEntry> {
+      return scanRepository(deps.repoDir, scanDeps);
+    },
+    async readFile(relativePath: string): Promise<string> {
+      return await readFile(path.join(deps.repoDir, relativePath), "utf8");
+    },
+  };
+}

--- a/packages/ingest-github/src/pipeline/git-diff.ts
+++ b/packages/ingest-github/src/pipeline/git-diff.ts
@@ -1,0 +1,158 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { IngestError } from "@bb/errors";
+
+const exec = promisify(execFile);
+
+export type DiffStatus = "added" | "modified" | "deleted" | "renamed";
+
+export interface RenamedFile {
+  oldPath: string;
+  newPath: string;
+  similarity: number;
+}
+
+export interface DiffResult {
+  added: string[];
+  modified: string[];
+  deleted: string[];
+  renamed: RenamedFile[];
+}
+
+export function emptyDiff(): DiffResult {
+  return { added: [], modified: [], deleted: [], renamed: [] };
+}
+
+/**
+ * Compute `git diff --name-status --find-renames=50 CURRENT..TARGET` in the
+ * given repo. Output is interpreted relative to the TARGET side of the
+ * comparison, so direction (forward / backward / sideways) does not matter
+ * to the caller.
+ */
+export async function diffCommits(repoDir: string, currentCommit: string, targetCommit: string): Promise<DiffResult> {
+  let stdout: string;
+  try {
+    const result = await exec(
+      "git",
+      ["-C", repoDir, "diff", "--name-status", "--find-renames=50", `${currentCommit}..${targetCommit}`],
+      { maxBuffer: 64 * 1024 * 1024 },
+    );
+    stdout = result.stdout;
+  } catch (cause: unknown) {
+    throw new IngestError("", `git diff ${currentCommit}..${targetCommit} failed: ${describe(cause)}`, cause);
+  }
+  return parseDiffOutput(stdout);
+}
+
+export function parseDiffOutput(stdout: string): DiffResult {
+  const out = emptyDiff();
+  const lines = stdout.split("\n");
+  for (const line of lines) {
+    if (line.length === 0) {
+      continue;
+    }
+    const parts = line.split("\t");
+    const code = parts[0];
+    if (code === undefined) {
+      continue;
+    }
+    if (code === "A") {
+      const path = parts[1];
+      if (path !== undefined && path.length > 0) {
+        out.added.push(path);
+      }
+      continue;
+    }
+    if (code === "M") {
+      const path = parts[1];
+      if (path !== undefined && path.length > 0) {
+        out.modified.push(path);
+      }
+      continue;
+    }
+    if (code === "D") {
+      const path = parts[1];
+      if (path !== undefined && path.length > 0) {
+        out.deleted.push(path);
+      }
+      continue;
+    }
+    if (code.startsWith("R")) {
+      const similarity = parseInt(code.slice(1), 10);
+      const oldPath = parts[1];
+      const newPath = parts[2];
+      if (oldPath !== undefined && newPath !== undefined && oldPath.length > 0 && newPath.length > 0) {
+        out.renamed.push({ oldPath, newPath, similarity: Number.isFinite(similarity) ? similarity : 0 });
+      }
+      continue;
+    }
+    if (code.startsWith("C")) {
+      // Copies: treat as additions of the new path; original is left untouched.
+      const newPath = parts[2];
+      if (newPath !== undefined && newPath.length > 0) {
+        out.added.push(newPath);
+      }
+      continue;
+    }
+    // Unknown status (T type-change, U unmerged, X, B). Conservative: ignore.
+  }
+  return out;
+}
+
+/** Returns true if `commitHash` exists in the local clone's object database. */
+export async function ensureCommitReachable(repoDir: string, commitHash: string): Promise<boolean> {
+  try {
+    await exec("git", ["-C", repoDir, "cat-file", "-e", `${commitHash}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns true if `commitHash` is an ancestor of (or equal to) `origin/<branch>`. */
+export async function assertReachableFromBranch(repoDir: string, commitHash: string, branch: string): Promise<boolean> {
+  try {
+    await exec("git", ["-C", repoDir, "merge-base", "--is-ancestor", commitHash, `origin/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the merge base of `a` and `b`, or null when histories are unrelated. */
+export async function mergeBaseOf(repoDir: string, a: string, b: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec("git", ["-C", repoDir, "merge-base", a, b]);
+    const value = stdout.trim();
+    return value.length === 40 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deepen the local clone by `depth` more commits on `origin/<branch>`.
+ * Returns true when the fetch succeeded, false otherwise. Failures are not
+ * fatal — the orchestrator decides what to do.
+ */
+export async function deepenClone(repoDir: string, branch: string, depth: number): Promise<boolean> {
+  try {
+    await exec("git", ["-C", repoDir, "fetch", `--deepen=${depth}`, "origin", branch]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Move the working tree to `commitHash` via `git checkout --force`. */
+export async function checkoutCommit(repoDir: string, commitHash: string): Promise<void> {
+  try {
+    await exec("git", ["-C", repoDir, "checkout", "--force", commitHash]);
+  } catch (cause: unknown) {
+    throw new IngestError("", `git checkout ${commitHash} failed: ${describe(cause)}`, cause);
+  }
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/ingest-github/src/pipeline/pull-diff-resolver.ts
+++ b/packages/ingest-github/src/pipeline/pull-diff-resolver.ts
@@ -1,0 +1,84 @@
+import { IngestError } from "@bb/errors";
+import { logger } from "@bb/logger";
+import { deepenClone, diffCommits, ensureCommitReachable, mergeBaseOf, type DiffResult } from "./git-diff.ts";
+
+const DEEPEN_PASSES: readonly number[] = [50, 200];
+
+/**
+ * Ensure both endpoints of a pull diff are reachable in the local clone.
+ * Tries up to two `git fetch --deepen` passes (50 then 200 commits). When
+ * both endpoints are already present, returns immediately without any
+ * network round-trip. The caller decides what to do if reachability is
+ * still false after both passes — typically falling through to the
+ * unrelated-history branch in `computePullDiff`.
+ */
+export async function materialiseEndpoints(
+  repoDir: string,
+  branch: string,
+  currentCommit: string,
+  targetCommit: string,
+): Promise<void> {
+  for (const depth of DEEPEN_PASSES) {
+    const haveCurrent = await ensureCommitReachable(repoDir, currentCommit);
+    const haveTarget = await ensureCommitReachable(repoDir, targetCommit);
+    if (haveCurrent && haveTarget) {
+      return;
+    }
+    logger.info(`pull: deepening clone to ${depth} on origin/${branch}`);
+    await deepenClone(repoDir, branch, depth);
+  }
+}
+
+/**
+ * Compute the diff between two commits, falling back to a merge-base
+ * union-diff when either endpoint is still unreachable after the deepen
+ * passes. The fallback produces a conservative change set — every file
+ * actually changed between current and target is included; some files may
+ * appear changed when content matches across history. The strategy
+ * re-analysing an unchanged file is wasteful, not incorrect.
+ *
+ * Throws `IngestError` when neither endpoint is reachable AND there is no
+ * merge base — an unrelated-history anomaly worth surfacing.
+ */
+export async function computePullDiff(
+  repoDir: string,
+  currentCommit: string,
+  targetCommit: string,
+): Promise<DiffResult> {
+  const haveCurrent = await ensureCommitReachable(repoDir, currentCommit);
+  const haveTarget = await ensureCommitReachable(repoDir, targetCommit);
+  if (haveCurrent && haveTarget) {
+    return await diffCommits(repoDir, currentCommit, targetCommit);
+  }
+  const base = await mergeBaseOf(repoDir, currentCommit, targetCommit);
+  if (base === null) {
+    throw new IngestError(
+      "",
+      `pull: cannot represent diff — endpoints unreachable and no merge base between ${currentCommit.slice(0, 12)} and ${targetCommit.slice(0, 12)}`,
+    );
+  }
+  logger.warn(`pull: endpoints unreachable; falling back to merge-base diff via ${base.slice(0, 12)}`);
+  const a = await diffCommits(repoDir, currentCommit, base);
+  const b = await diffCommits(repoDir, base, targetCommit);
+  return unionDiff(a, b);
+}
+
+/**
+ * Union two `DiffResult` change sets. Conservative — paths that appear in
+ * both sides are deduped; rename entries are deduped by `newPath`.
+ */
+export function unionDiff(a: DiffResult, b: DiffResult): DiffResult {
+  const added = new Set<string>([...a.added, ...b.added]);
+  const modified = new Set<string>([...a.modified, ...b.modified]);
+  const deleted = new Set<string>([...a.deleted, ...b.deleted]);
+  const renamesByNewPath = new Map<string, { oldPath: string; newPath: string; similarity: number }>();
+  for (const r of [...a.renamed, ...b.renamed]) {
+    renamesByNewPath.set(r.newPath, r);
+  }
+  return {
+    added: [...added],
+    modified: [...modified],
+    deleted: [...deleted],
+    renamed: [...renamesByNewPath.values()],
+  };
+}

--- a/packages/ingest-github/src/pipeline/pull.ts
+++ b/packages/ingest-github/src/pipeline/pull.ts
@@ -1,0 +1,245 @@
+import { Config, KnowledgeState, type GithubPullPayload, type JobMessage } from "@bb/types";
+import { getConfigValue } from "@bb/config";
+import { getKnowledge, recordProcessingStats, setKnowledgeCommit, setKnowledgeState } from "@bb/mongo";
+import { setKnowledgeStateInGraph, snapshotFilesToVersion, type NodeScope } from "@bb/neo4j";
+import { estimateCostFromBreakdown } from "@bb/llm";
+import { IngestError, KnowledgeNotFoundError } from "@bb/errors";
+import { logger } from "@bb/logger";
+import { ensureMetaDirs, metaPathsFor, repoCloneDir, ensureReposRoot } from "./paths.ts";
+import { readHeadCommitHash, syncRepository } from "./source.ts";
+import { CancellationError, clearCancellation, throwIfCancelled } from "./cancellation.ts";
+import { assertReachableFromBranch, checkoutCommit } from "./git-diff.ts";
+import { computePullDiff, materialiseEndpoints } from "./pull-diff-resolver.ts";
+import { affectedFoldersFromDiff } from "./affected-folders.ts";
+import { createDiskSourceReader } from "./disk-source-reader.ts";
+import { analyseChangedFiles } from "src/strategies/flat-folder/analyse-changed.ts";
+import { processBigFilesQueue } from "src/strategies/flat-folder/phases/process-big-files.ts";
+import { backfillMissingFields } from "src/strategies/flat-folder/backfill/fields.ts";
+import { backfillBigFiles } from "src/strategies/flat-folder/backfill/big-files.ts";
+import { runSelectiveFolderSummary } from "src/strategies/flat-folder/folder-summary-selective.ts";
+import { makeRepoSummaryEnvelope, persistRepoSummary, summariseRepo } from "src/strategies/flat-folder/repo-summary.ts";
+import { storePullAnalysis } from "src/strategies/flat-folder/store-pull.ts";
+import { createLlmFileAnalyzer } from "src/adapters/llm-file-analyzer.ts";
+import {
+  COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
+  buildFileAnalysisUserPrompt,
+} from "src/strategies/flat-folder/prompts/file-analysis.ts";
+
+const COMMIT_HASH_RE = /^[0-9a-f]{40}$/u;
+
+function resolveOrgId(payload: { orgId?: string }): string {
+  if (typeof payload.orgId === "string" && payload.orgId.length > 0) {
+    return payload.orgId;
+  }
+  return getConfigValue(Config.OrgId);
+}
+
+export async function runPull(msg: JobMessage<GithubPullPayload>): Promise<void> {
+  const { knowledgeId } = msg.payload;
+  if (msg.payload.targetCommitHash !== undefined && !COMMIT_HASH_RE.test(msg.payload.targetCommitHash)) {
+    throw new IngestError(
+      knowledgeId,
+      `targetCommitHash must be a 40-character hex SHA, got: ${msg.payload.targetCommitHash}`,
+    );
+  }
+
+  const knowledge = await getKnowledge(knowledgeId);
+  if (knowledge === null) {
+    throw new KnowledgeNotFoundError(knowledgeId);
+  }
+  if (knowledge.source.kind !== "github") {
+    throw new IngestError(knowledgeId, `pull is only supported for github knowledge (kind=${knowledge.source.kind})`);
+  }
+  const currentCommit = knowledge.source.commitId ?? "";
+  if (currentCommit.length === 0) {
+    throw new IngestError(
+      knowledgeId,
+      "pull requires a previously-indexed commit; this knowledge has no commitId. Run github_index first.",
+    );
+  }
+
+  const branch = knowledge.source.branch ?? "main";
+  const repoUrl = knowledge.source.repoUrl;
+  const gitToken = msg.payload.gitToken;
+
+  clearCancellation(knowledgeId);
+  const startedAt = Date.now();
+  await transitionState(knowledgeId, KnowledgeState.Processing);
+
+  try {
+    throwIfCancelled(knowledgeId);
+    await ensureReposRoot();
+    const repoDir = repoCloneDir(knowledgeId);
+    const cloneOpts: { repoUrl: string; branch: string; destinationDir: string; gitToken?: string } = {
+      repoUrl,
+      branch,
+      destinationDir: repoDir,
+    };
+    if (gitToken !== undefined) {
+      cloneOpts.gitToken = gitToken;
+    }
+    await syncRepository(cloneOpts);
+
+    const branchHead = await readHeadCommitHash(repoDir);
+    if (branchHead === "unknown") {
+      throw new IngestError(knowledgeId, "could not resolve branch HEAD after clone");
+    }
+    const targetCommit = msg.payload.targetCommitHash ?? branchHead;
+
+    if (targetCommit === currentCommit) {
+      logger.info(`pull: ${knowledgeId} already at ${targetCommit.slice(0, 12)}; no-op`);
+      await transitionState(knowledgeId, KnowledgeState.Processed);
+      return;
+    }
+
+    if (!(await assertReachableFromBranch(repoDir, targetCommit, branch))) {
+      throw new IngestError(
+        knowledgeId,
+        `target commit ${targetCommit} is not reachable from origin/${branch}. Cross-branch pulls are not supported; create a fresh github_index job for the new branch.`,
+      );
+    }
+
+    await materialiseEndpoints(repoDir, branch, currentCommit, targetCommit);
+
+    const diff = await computePullDiff(repoDir, currentCommit, targetCommit);
+
+    throwIfCancelled(knowledgeId);
+    await snapshotFilesToVersion({ knowledgeId, commitHash: currentCommit }).catch((cause: unknown) => {
+      const msgText = cause instanceof Error ? cause.message : String(cause);
+      logger.warn(`pull: snapshot of ${currentCommit.slice(0, 12)} failed (non-fatal): ${msgText}`);
+    });
+
+    await checkoutCommit(repoDir, targetCommit);
+
+    const metaPaths = metaPathsFor(knowledgeId);
+    await ensureMetaDirs(metaPaths);
+
+    const affectedFolders = affectedFoldersFromDiff(diff);
+
+    const fileAnalyzer = createLlmFileAnalyzer({
+      buildSystemPrompt: () => COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
+      buildUserPrompt: buildFileAnalysisUserPrompt,
+    });
+
+    logger.info(`pull: phase per-file dispatcher for ${knowledgeId} starting`);
+    throwIfCancelled(knowledgeId);
+    await analyseChangedFiles({
+      knowledgeId,
+      repoDir,
+      metaPaths,
+      analyzer: fileAnalyzer,
+      diff,
+    });
+
+    const source = createDiskSourceReader({ repoDir, commitHash: targetCommit });
+
+    logger.info(`pull: phase process big files starting`);
+    throwIfCancelled(knowledgeId);
+    await processBigFilesQueue({ knowledgeId, source, metaPaths });
+
+    logger.info(`pull: phase backfill fields starting`);
+    throwIfCancelled(knowledgeId);
+    await backfillMissingFields(metaPaths);
+
+    logger.info(`pull: phase backfill big-files starting`);
+    throwIfCancelled(knowledgeId);
+    await backfillBigFiles({ knowledgeId, source, metaPaths });
+
+    logger.info(`pull: phase selective folder summary (${affectedFolders.size} folders) starting`);
+    throwIfCancelled(knowledgeId);
+    await runSelectiveFolderSummary({ knowledgeId, metaPaths, affectedFolders });
+
+    logger.info(`pull: phase repo summary starting`);
+    throwIfCancelled(knowledgeId);
+    const orgId = resolveOrgId({ ...(knowledge.source.kind === "github" ? {} : {}) });
+    const scope: NodeScope = { orgId, knowledgeId, repoId: knowledgeId };
+    const repoSummary = await summariseRepo(knowledgeId, metaPaths);
+    if (repoSummary !== null) {
+      await persistRepoSummary(metaPaths, makeRepoSummaryEnvelope(knowledgeId, orgId, repoSummary));
+    }
+
+    logger.info(`pull: phase graph store starting`);
+    throwIfCancelled(knowledgeId);
+    const stored = await storePullAnalysis({
+      scope,
+      payload: { knowledgeId, repoUrl, branch },
+      branch,
+      metaPaths,
+      diff,
+      affectedFolders,
+    });
+
+    await persistPullStats({
+      knowledgeId,
+      repoName: repoNameFromUrl(repoUrl),
+      commitHash: targetCommit,
+      filesAnalyzed: stored.filesUpserted,
+      foldersSummarised: stored.foldersUpserted,
+      processingTimeMs: Date.now() - startedAt,
+    });
+    await setKnowledgeCommit(knowledgeId, targetCommit);
+    await transitionState(knowledgeId, KnowledgeState.Processed);
+    logger.info(
+      `pull: ${knowledgeId} ${currentCommit.slice(0, 12)} -> ${targetCommit.slice(0, 12)} done (filesUpserted=${stored.filesUpserted} filesDeleted=${stored.filesDeleted} foldersUpserted=${stored.foldersUpserted})`,
+    );
+  } catch (cause: unknown) {
+    if (cause instanceof CancellationError) {
+      clearCancellation(knowledgeId);
+      logger.info(`pull: cancelled for ${knowledgeId}`);
+      throw cause;
+    }
+    await transitionState(knowledgeId, KnowledgeState.Failed).catch(() => undefined);
+    throw new IngestError(knowledgeId, `github_pull failed: ${describe(cause)}`, cause);
+  }
+}
+
+async function transitionState(knowledgeId: string, state: KnowledgeState): Promise<void> {
+  await setKnowledgeState(knowledgeId, state);
+  await setKnowledgeStateInGraph(knowledgeId, state).catch(() => undefined);
+}
+
+interface PersistPullStatsInput {
+  knowledgeId: string;
+  repoName: string;
+  commitHash: string;
+  filesAnalyzed: number;
+  foldersSummarised: number;
+  processingTimeMs: number;
+}
+
+async function persistPullStats(input: PersistPullStatsInput): Promise<void> {
+  const estimatedCost = await estimateCostFromBreakdown({});
+  await recordProcessingStats({
+    knowledgeId: input.knowledgeId,
+    repoName: input.repoName,
+    commitHash: input.commitHash,
+    modelTokens: {},
+    estimatedCost,
+    totalBatches: 1,
+    totalFiles: input.filesAnalyzed,
+    totalFolders: input.foldersSummarised,
+    filesAnalyzed: input.filesAnalyzed,
+    processingTimeMs: input.processingTimeMs,
+  });
+}
+
+function repoNameFromUrl(repoUrl: string): string {
+  try {
+    const segments = new URL(repoUrl).pathname
+      .split("/")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const repo = segments.at(-1)?.replace(/\.git$/u, "");
+    const owner = segments.at(-2);
+    if (owner !== undefined && repo !== undefined) {
+      return `${owner}/${repo}`;
+    }
+  } catch {
+    // fall through
+  }
+  return repoUrl;
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/ingest-github/src/pipeline/pull.ts
+++ b/packages/ingest-github/src/pipeline/pull.ts
@@ -92,14 +92,17 @@ export async function runPull(msg: JobMessage<GithubPullPayload>): Promise<void>
       return;
     }
 
+    // Deepen the shallow clone first so historical commits selected via the
+    // picker become visible to `merge-base --is-ancestor`. Without this the
+    // assertion below rejects every non-HEAD pick on a `--depth=1` clone.
+    await materialiseEndpoints(repoDir, branch, currentCommit, targetCommit);
+
     if (!(await assertReachableFromBranch(repoDir, targetCommit, branch))) {
       throw new IngestError(
         knowledgeId,
         `target commit ${targetCommit} is not reachable from origin/${branch}. Cross-branch pulls are not supported; create a fresh github_index job for the new branch.`,
       );
     }
-
-    await materialiseEndpoints(repoDir, branch, currentCommit, targetCommit);
 
     const diff = await computePullDiff(repoDir, currentCommit, targetCommit);
 

--- a/packages/ingest-github/src/pipeline/run.ts
+++ b/packages/ingest-github/src/pipeline/run.ts
@@ -7,11 +7,12 @@ import { IngestError } from "@bb/errors";
 import { logger } from "@bb/logger";
 import type { IngestRunnerDeps, IngestRunnerInput } from "src/types/ingest-runner.ts";
 import type { IngestStrategy } from "src/types/strategy.ts";
-import type { PipelineSummary } from "src/types/pipeline.ts";
+import type { ArchiveSink, PipelineSummary, SourceFactory, SourceReader } from "src/types/pipeline.ts";
 import { ensureMetaDirs, ensureReposRoot, metaPathsFor, repoCloneDir } from "./paths.ts";
 import { readHeadCommitHash, syncRepository } from "./source.ts";
 import { resolveBranch } from "./branch.ts";
 import { CancellationError, clearCancellation, throwIfCancelled } from "./cancellation.ts";
+import { createDiskSourceReader } from "./disk-source-reader.ts";
 
 function resolveOrgId(payload: { orgId?: string }): string {
   if (typeof payload.orgId === "string" && payload.orgId.length > 0) {
@@ -23,6 +24,13 @@ function resolveOrgId(payload: { orgId?: string }): string {
 export interface CreatePipelineRunnerDeps {
   reposRootDir: string;
   strategy: IngestStrategy;
+  /**
+   * Optional source factory. When provided, GitHub-ingest skips the default
+   * disk clone and uses the factory's returned reader instead. The factory is
+   * documented in `docs/extension-points.md`; the open-source binary never
+   * supplies one.
+   */
+  sourceFactory?: SourceFactory;
 }
 
 export function createPipelineRunner(deps: CreatePipelineRunnerDeps): IngestRunnerDeps {
@@ -32,14 +40,18 @@ export function createPipelineRunner(deps: CreatePipelineRunnerDeps): IngestRunn
     run: async (input: IngestRunnerInput): Promise<PipelineSummary> => {
       const payload = input.payload;
       if (isGithubPayload(payload)) {
-        return await runGithub(deps.strategy, payload);
+        return await runGithub(deps.strategy, payload, deps.sourceFactory);
       }
       return await runLocal(deps.strategy, payload);
     },
   };
 }
 
-async function runGithub(strategy: IngestStrategy, payload: GithubIndexPayload): Promise<PipelineSummary> {
+async function runGithub(
+  strategy: IngestStrategy,
+  payload: GithubIndexPayload,
+  sourceFactory: SourceFactory | undefined,
+): Promise<PipelineSummary> {
   const { knowledgeId } = payload;
   clearCancellation(knowledgeId);
   const startedAt = Date.now();
@@ -47,32 +59,50 @@ async function runGithub(strategy: IngestStrategy, payload: GithubIndexPayload):
   try {
     throwIfCancelled(knowledgeId);
     const branch = resolveBranch(knowledgeId, payload);
-    await ensureReposRoot();
-    const repoDir = repoCloneDir(knowledgeId);
-    const cloneOpts: { repoUrl: string; branch: string; destinationDir: string; gitToken?: string } = {
-      repoUrl: payload.repoUrl,
-      branch,
-      destinationDir: repoDir,
-    };
-    if (payload.gitToken !== undefined) {
-      cloneOpts.gitToken = payload.gitToken;
-    }
-    await syncRepository(cloneOpts);
 
-    const commitHash = await readHeadCommitHash(repoDir);
-    if (commitHash === "unknown") {
-      throw new IngestError(knowledgeId, "could not resolve HEAD commit hash after clone");
+    let source: SourceReader;
+    let archiveSink: ArchiveSink | undefined;
+    let commitHash: string;
+
+    if (sourceFactory !== undefined) {
+      const factoryResult = await sourceFactory({ knowledgeId, payload, branch });
+      source = factoryResult.source;
+      commitHash = factoryResult.commitHash;
+      archiveSink = factoryResult.archiveSink;
+      logger.info(`pipeline/run: source factory wired (knowledgeId=${knowledgeId}, commit=${commitHash.slice(0, 12)})`);
+    } else {
+      await ensureReposRoot();
+      const repoDir = repoCloneDir(knowledgeId);
+      const cloneOpts: { repoUrl: string; branch: string; destinationDir: string; gitToken?: string } = {
+        repoUrl: payload.repoUrl,
+        branch,
+        destinationDir: repoDir,
+      };
+      if (payload.gitToken !== undefined) {
+        cloneOpts.gitToken = payload.gitToken;
+      }
+      await syncRepository(cloneOpts);
+      commitHash = await readHeadCommitHash(repoDir);
+      if (commitHash === "unknown") {
+        throw new IngestError(knowledgeId, "could not resolve HEAD commit hash after clone");
+      }
+      source = createDiskSourceReader({ repoDir, commitHash });
     }
+
     const metaPaths = metaPathsFor(knowledgeId);
     await ensureMetaDirs(metaPaths);
 
-    const result = await strategy.execute({
+    const strategyInput: Parameters<typeof strategy.execute>[0] = {
       payload,
       branch,
-      repoDir,
+      source,
       metaPaths,
       context: { knowledgeId, orgId: resolveOrgId(payload), repoId: knowledgeId },
-    });
+    };
+    if (archiveSink !== undefined) {
+      strategyInput.archiveSink = archiveSink;
+    }
+    const result = await strategy.execute(strategyInput);
 
     await persistStats({
       knowledgeId,
@@ -113,10 +143,12 @@ async function runLocal(strategy: IngestStrategy, payload: LocalIngestPayload): 
     const metaPaths = metaPathsFor(knowledgeId);
     await ensureMetaDirs(metaPaths);
 
+    const source = createDiskSourceReader({ repoDir: rootDir, commitHash: `local-${startedAt}` });
+
     const result = await strategy.execute({
       payload: { knowledgeId, repoUrl: `local:${rootDir}` },
       branch: "local",
-      repoDir: rootDir,
+      source,
       metaPaths,
       context: { knowledgeId, orgId: resolveOrgId(payload), repoId: knowledgeId },
     });

--- a/packages/ingest-github/src/pipeline/skip-decisions/decider.ts
+++ b/packages/ingest-github/src/pipeline/skip-decisions/decider.ts
@@ -91,13 +91,17 @@ export function makeSkipDecider(deps: SkipDeciderDeps = {}): SkipDecider {
 async function askLlmDecision(input: SkipDeciderInput, repositoryName: string | undefined): Promise<boolean> {
   const maxChars = getConfigValue(Config.SkipDecisionMaxCharsForLlm);
   let content: string;
-  try {
-    const raw = await readFile(input.absolutePath, "utf8");
-    content = raw.slice(0, maxChars);
-  } catch (cause: unknown) {
-    const msg = cause instanceof Error ? cause.message : String(cause);
-    logger.warn(`skip-decisions: cannot read ${input.relativePath} for LLM check (${msg}); defaulting to reject`);
-    return false;
+  if (input.content !== undefined) {
+    content = input.content.slice(0, maxChars);
+  } else {
+    try {
+      const raw = await readFile(input.absolutePath, "utf8");
+      content = raw.slice(0, maxChars);
+    } catch (cause: unknown) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      logger.warn(`skip-decisions: cannot read ${input.relativePath} for LLM check (${msg}); defaulting to reject`);
+      return false;
+    }
   }
 
   logger.info(

--- a/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
@@ -1,0 +1,222 @@
+import path from "node:path";
+import { readFile, stat } from "node:fs/promises";
+import { tokenLen } from "@bb/llm";
+import { logger } from "@bb/logger";
+import { Config } from "@bb/types";
+import { getConfigValue } from "@bb/config";
+import type { FileAnalyzer, ScannedFile } from "src/types/pipeline.ts";
+import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { BigFileEntry } from "src/types/big-file.ts";
+import { looksBinary, passesPathFilters } from "src/pipeline/filters.ts";
+import { withConcurrency } from "src/pipeline/concurrency.ts";
+import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
+import type { DiffResult } from "src/pipeline/git-diff.ts";
+import { analyseScannedFile, buildOversizedStub } from "src/strategies/flat-folder/analyse-file.ts";
+import { saveCondensed } from "src/strategies/flat-folder/big-file/storage.ts";
+import { readBigFiles, writeBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
+
+export interface AnalyseChangedInput {
+  knowledgeId: string;
+  repoDir: string;
+  metaPaths: MetaPaths;
+  analyzer: FileAnalyzer;
+  diff: DiffResult;
+}
+
+export interface AnalyseChangedResult {
+  smallFilesAnalysed: number;
+  bigFilesQueued: number;
+  oversizedStubs: number;
+  skipped: number;
+  failed: number;
+}
+
+/**
+ * Pull-time per-file dispatcher. Iterates the changed file set from the git
+ * diff and runs the same per-file work as `classifyAndAnalyseSmall`, but
+ * targeted at known paths rather than a tree walk.
+ *
+ * For added / modified / renamed-to paths: read content, apply static path
+ * filters, classify by tokens. Small files run the analyser inline and
+ * persist a `CondensedFileAnalysis`. Files above the context window join
+ * `bigFiles.json` for the big-file phase. Files above the absolute size cap
+ * get an oversized stub.
+ *
+ * The dispatcher does NOT invoke the skip-decision LLM gate. Pulls re-analyse
+ * paths that already passed the gate during the initial index (or paths so
+ * new the gate has not seen them yet — for v1 we accept that lag).
+ */
+export async function analyseChangedFiles(input: AnalyseChangedInput): Promise<AnalyseChangedResult> {
+  const contextWindowLimit = getConfigValue(Config.ContextWindowLimit);
+  const absoluteCap = getConfigValue(Config.AbsoluteFileSizeCap);
+  const bigFileLineThreshold = getConfigValue(Config.BigFileLineThreshold);
+  const concurrentWorkers = getConfigValue(Config.ConcurrentWorkers);
+  const limit = withConcurrency(concurrentWorkers);
+
+  const newPaths: string[] = [...input.diff.added, ...input.diff.modified, ...input.diff.renamed.map((r) => r.newPath)];
+  const seen = new Set<string>();
+  const dedupedPaths = newPaths.filter((p) => {
+    if (seen.has(p)) {
+      return false;
+    }
+    seen.add(p);
+    return true;
+  });
+
+  const bigFileBuffer: BigFileEntry[] = [];
+  let smallFilesAnalysed = 0;
+  let oversizedStubs = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const pending: Promise<void>[] = [];
+
+  for (const relativePath of dedupedPaths) {
+    throwIfCancelled(input.knowledgeId);
+    const filename = path.basename(relativePath);
+    const ext = path.extname(filename).toLowerCase();
+    if (!passesPathFilters(filename, ext)) {
+      skipped += 1;
+      continue;
+    }
+
+    const abs = path.join(input.repoDir, relativePath);
+    let sizeBytes: number;
+    try {
+      sizeBytes = (await stat(abs)).size;
+    } catch (cause: unknown) {
+      failed += 1;
+      logger.warn(`pull-analyse: stat failed for ${relativePath}: ${describe(cause)}`);
+      continue;
+    }
+
+    if (sizeBytes > absoluteCap) {
+      bigFileBuffer.push({
+        relativePath,
+        sizeBytes,
+        tokenCount: 0,
+        reason: "too-large",
+      });
+      try {
+        await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
+        oversizedStubs += 1;
+      } catch (cause: unknown) {
+        failed += 1;
+        logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
+      }
+      continue;
+    }
+
+    let buf: Buffer;
+    try {
+      buf = await readFile(abs);
+    } catch (cause: unknown) {
+      failed += 1;
+      logger.warn(`pull-analyse: read failed for ${relativePath}: ${describe(cause)}`);
+      continue;
+    }
+    if (looksBinary(buf)) {
+      skipped += 1;
+      continue;
+    }
+    const content = buf.toString("utf8");
+    if (countLines(content) > bigFileLineThreshold) {
+      bigFileBuffer.push({
+        relativePath,
+        sizeBytes,
+        tokenCount: 0,
+        reason: "too-large",
+      });
+      try {
+        await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
+        oversizedStubs += 1;
+      } catch (cause: unknown) {
+        failed += 1;
+        logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
+      }
+      continue;
+    }
+
+    const tokenCount = tokenLen(content);
+    if (tokenCount > contextWindowLimit) {
+      bigFileBuffer.push({
+        relativePath,
+        sizeBytes,
+        tokenCount,
+        reason: "context-window-exceeded",
+      });
+      continue;
+    }
+
+    const scanned: ScannedFile = {
+      kind: "file",
+      relativePath,
+      absolutePath: abs,
+      sizeBytes,
+      content,
+    };
+    pending.push(
+      limit(async () => {
+        try {
+          throwIfCancelled(input.knowledgeId);
+          const condensed = await analyseScannedFile(input.analyzer, scanned);
+          await saveCondensed(input.metaPaths, condensed);
+          smallFilesAnalysed += 1;
+        } catch (cause: unknown) {
+          if (cause instanceof CancellationError) {
+            throw cause;
+          }
+          failed += 1;
+          logger.warn(`pull-analyse: analyse failed for ${relativePath}: ${describe(cause)}`);
+        }
+      }),
+    );
+  }
+
+  await Promise.all(pending);
+
+  if (bigFileBuffer.length > 0) {
+    const existing = await readBigFiles(input.metaPaths);
+    const merged = mergeBigFileEntries(existing, bigFileBuffer);
+    await writeBigFiles(input.metaPaths, merged);
+  }
+
+  logger.info(
+    `pull-analyse done: smallFilesAnalysed=${smallFilesAnalysed} bigFilesQueued=${bigFileBuffer.filter((e) => e.reason === "context-window-exceeded").length} oversizedStubs=${oversizedStubs} skipped=${skipped} failed=${failed}`,
+  );
+  return {
+    smallFilesAnalysed,
+    bigFilesQueued: bigFileBuffer.filter((e) => e.reason === "context-window-exceeded").length,
+    oversizedStubs,
+    skipped,
+    failed,
+  };
+}
+
+function mergeBigFileEntries(existing: BigFileEntry[], additions: BigFileEntry[]): BigFileEntry[] {
+  const byPath = new Map<string, BigFileEntry>();
+  for (const entry of existing) {
+    byPath.set(entry.relativePath, entry);
+  }
+  for (const entry of additions) {
+    byPath.set(entry.relativePath, entry);
+  }
+  return [...byPath.values()];
+}
+
+function countLines(content: string): number {
+  if (content.length === 0) {
+    return 0;
+  }
+  let lines = 1;
+  for (let i = 0; i < content.length; i += 1) {
+    if (content.charCodeAt(i) === 10) {
+      lines += 1;
+    }
+  }
+  return lines;
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
@@ -21,6 +21,13 @@ export interface AnalyseChangedInput {
   metaPaths: MetaPaths;
   analyzer: FileAnalyzer;
   diff: DiffResult;
+  /**
+   * Invoked once per consumed path (analysed, stubbed, queued-as-big-file,
+   * filtered, or failed). Lets the caller drive a `processedFiles` counter
+   * for the progress bar without coupling this strategy to mongo. Best
+   * effort — errors from the callback are swallowed.
+   */
+  onFileProcessed?: () => Promise<void> | void;
 }
 
 export interface AnalyseChangedResult {

--- a/packages/ingest-github/src/strategies/flat-folder/backfill/big-files.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/backfill/big-files.ts
@@ -1,14 +1,13 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { logger } from "@bb/logger";
 import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { SourceReader } from "src/types/pipeline.ts";
 import { readBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
 import { inspect } from "src/strategies/flat-folder/big-file/cache.ts";
 import { processBigFile } from "src/strategies/flat-folder/big-file/index.ts";
 
 export interface BackfillBigFilesInput {
   knowledgeId: string;
-  repoDir: string;
+  source: SourceReader;
   metaPaths: MetaPaths;
 }
 
@@ -30,7 +29,12 @@ export async function backfillBigFiles(input: BackfillBigFilesInput): Promise<Ba
       continue;
     }
     try {
-      const content = await readFile(path.join(input.repoDir, entry.relativePath), "utf8");
+      const content = await input.source.readFile(entry.relativePath);
+      if (content.length === 0) {
+        failed += 1;
+        logger.warn(`phase4: empty content for ${entry.relativePath}; skipping`);
+        continue;
+      }
       await processBigFile({
         knowledgeId: input.knowledgeId,
         metaPaths: input.metaPaths,

--- a/packages/ingest-github/src/strategies/flat-folder/context.md
+++ b/packages/ingest-github/src/strategies/flat-folder/context.md
@@ -8,12 +8,13 @@ sub-phase boundary.
 ## Phases
 
 1. **classify-and-analyse-small** (`phases/classify-and-analyse-small.ts`) —
-   walks `scanRepository(repoDir)`; small files → LLM file-analysis → write
-   `CondensedFileAnalysis`. Oversized files → write a stub. Big-by-tokens
+   walks `source.scan({ skipDecider })`; small files → LLM file-analysis →
+   write `CondensedFileAnalysis` Oversized files → write a stub. Big-by-tokens
    files → append to `bigFiles.json` for Phase 2.
 2. **process-big-files** (`phases/process-big-files.ts`) — reads
-   `bigFiles.json`, dispatches `processBigFile` per entry sequentially
-   (chunk-level concurrency inside).
+   `bigFiles.json`, calls `source.readFile(relativePath)` per entry,
+   dispatches `processBigFile` sequentially (chunk-level concurrency
+   inside).
 3. **backfill-fields** (`backfill/fields.ts`) — top up `keywords`,
    `sideEffects`, `configDependencies`, `dataFlowDirection` on condensed
    entries that miss them. Idempotent.
@@ -55,3 +56,13 @@ sub-phase boundary.
 - `throwIfCancelled(knowledgeId)` runs at every phase boundary and between
   big-file chunks. A cancellation re-throws past the strategy boundary so
   the orchestrator clears the cancel flag without setting FAILED state.
+- **All file content access goes through `input.source` (a `SourceReader`).**
+  No phase calls `fs.readFile`, `path.join(repoDir, …)`, or
+  `scanRepository(rootDir)` directly. This keeps the strategy decoupled
+  from any specific reader implementation; any caller that supplies an
+  alternative reader through the `sourceFactory` hook (see
+  `docs/extension-points.md`) gets the same seven-phase pipeline unchanged.
+- **Archive push is best-effort.** Phase 1 calls `input.archiveSink?.push`
+  after `saveCondensed`; failures inside the sink are logged WARN and do
+  not interrupt the analyse loop. The open-source binary never wires a
+  sink — `archiveSink` is undefined and the call is skipped entirely.

--- a/packages/ingest-github/src/strategies/flat-folder/folder-summary-selective.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/folder-summary-selective.ts
@@ -1,0 +1,69 @@
+import { logger } from "@bb/logger";
+import { Config } from "@bb/types";
+import { getConfigValue } from "@bb/config";
+import type { MetaPaths } from "src/types/meta-paths.ts";
+import { withConcurrency } from "src/pipeline/concurrency.ts";
+import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
+import {
+  groupByDirectFolder,
+  persistFolderSummary,
+  summariseFolder,
+} from "src/strategies/flat-folder/folder-summary.ts";
+
+export interface SelectiveFolderSummaryInput {
+  knowledgeId: string;
+  metaPaths: MetaPaths;
+  affectedFolders: Set<string>;
+}
+
+export interface SelectiveFolderSummaryResult {
+  succeeded: number;
+  failed: number;
+  skipped: number;
+}
+
+/**
+ * Pull-time folder summary. Same machinery as `runFolderSummaryPhase` but
+ * only regenerates folders the caller flagged as affected. Reads condensed
+ * file analyses from disk; the dispatcher must have populated them already.
+ */
+export async function runSelectiveFolderSummary(
+  input: SelectiveFolderSummaryInput,
+): Promise<SelectiveFolderSummaryResult> {
+  const concurrentWorkers = getConfigValue(Config.ConcurrentWorkers);
+  const limit = withConcurrency(concurrentWorkers);
+  const groups = await groupByDirectFolder(input.metaPaths);
+  let succeeded = 0;
+  let failed = 0;
+  let skipped = 0;
+  const tasks: Promise<void>[] = [];
+  for (const [folderPath, files] of groups.entries()) {
+    if (!input.affectedFolders.has(folderPath)) {
+      skipped += 1;
+      continue;
+    }
+    tasks.push(
+      limit(async () => {
+        try {
+          throwIfCancelled(input.knowledgeId);
+          const summary = await summariseFolder(folderPath, files);
+          if (summary !== null) {
+            await persistFolderSummary(input.metaPaths, summary);
+            succeeded += 1;
+          } else {
+            failed += 1;
+          }
+        } catch (cause: unknown) {
+          if (cause instanceof CancellationError) {
+            throw cause;
+          }
+          failed += 1;
+          logger.warn(`pull-folder-summary: failed for ${folderPath || "<root>"}`);
+        }
+      }),
+    );
+  }
+  await Promise.all(tasks);
+  logger.info(`pull-folder-summary done: succeeded=${succeeded} failed=${failed} skipped=${skipped}`);
+  return { succeeded, failed, skipped };
+}

--- a/packages/ingest-github/src/strategies/flat-folder/index.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/index.ts
@@ -18,21 +18,25 @@ export function createFlatFolderStrategy(deps: FlatFolderStrategyDeps): IngestSt
   return {
     name: "flat-folder",
     async execute(input: StrategyInput): Promise<StrategyResult> {
-      const { context, repoDir, metaPaths, payload, branch } = input;
+      const { context, source, archiveSink, metaPaths, payload, branch } = input;
       const { knowledgeId, orgId, repoId } = context;
 
       logger.info(`flat-folder: phase1 (classify + analyse small) starting for ${knowledgeId}`);
       throwIfCancelled(knowledgeId);
-      const phase1 = await classifyAndAnalyseSmall({
+      const phase1Input: Parameters<typeof classifyAndAnalyseSmall>[0] = {
         knowledgeId,
-        repoDir,
+        source,
         metaPaths,
         analyzer: deps.fileAnalyzer,
-      });
+      };
+      if (archiveSink !== undefined) {
+        phase1Input.archiveSink = archiveSink;
+      }
+      const phase1 = await classifyAndAnalyseSmall(phase1Input);
 
       logger.info(`flat-folder: phase2 (process big files) starting`);
       throwIfCancelled(knowledgeId);
-      const phase2 = await processBigFilesQueue({ knowledgeId, repoDir, metaPaths });
+      const phase2 = await processBigFilesQueue({ knowledgeId, source, metaPaths });
 
       logger.info(`flat-folder: phase3 (backfill missing fields) starting`);
       throwIfCancelled(knowledgeId);
@@ -40,7 +44,7 @@ export function createFlatFolderStrategy(deps: FlatFolderStrategyDeps): IngestSt
 
       logger.info(`flat-folder: phase4 (backfill big files) starting`);
       throwIfCancelled(knowledgeId);
-      await backfillBigFiles({ knowledgeId, repoDir, metaPaths });
+      await backfillBigFiles({ knowledgeId, source, metaPaths });
 
       logger.info(`flat-folder: phase5 (folder summaries) starting`);
       throwIfCancelled(knowledgeId);

--- a/packages/ingest-github/src/strategies/flat-folder/phases/classify-and-analyse-small.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/classify-and-analyse-small.ts
@@ -3,10 +3,9 @@ import { tokenLen } from "@bb/llm";
 import { logger } from "@bb/logger";
 import { Config } from "@bb/types";
 import { getConfigValue } from "@bb/config";
-import type { FileAnalyzer, SkipDecider } from "src/types/pipeline.ts";
+import type { ArchiveSink, FileAnalyzer, SkipDecider, SourceReader } from "src/types/pipeline.ts";
 import type { MetaPaths } from "src/types/meta-paths.ts";
 import type { BigFileEntry } from "src/types/big-file.ts";
-import { scanRepository } from "src/pipeline/scan.ts";
 import { withConcurrency } from "src/pipeline/concurrency.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
 import { makeSkipDecider } from "src/pipeline/skip-decisions/index.ts";
@@ -16,10 +15,11 @@ import { writeBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
 
 export interface ClassifyPhaseInput {
   knowledgeId: string;
-  repoDir: string;
+  source: SourceReader;
   metaPaths: MetaPaths;
   analyzer: FileAnalyzer;
   skipDecider?: SkipDecider;
+  archiveSink?: ArchiveSink;
 }
 
 export interface ClassifyPhaseResult {
@@ -38,11 +38,13 @@ export async function classifyAndAnalyseSmall(input: ClassifyPhaseInput): Promis
   let oversizedStubs = 0;
   let failed = 0;
 
-  const skipDecider = input.skipDecider ?? makeSkipDecider({ repositoryName: path.basename(input.repoDir) });
+  const repositoryHint =
+    input.source.localRepoDir.length > 0 ? path.basename(input.source.localRepoDir) : input.knowledgeId;
+  const skipDecider = input.skipDecider ?? makeSkipDecider({ repositoryName: repositoryHint });
 
   const pending: Promise<void>[] = [];
 
-  for await (const entry of scanRepository(input.repoDir, { skipDecider })) {
+  for await (const entry of input.source.scan({ skipDecider })) {
     throwIfCancelled(input.knowledgeId);
 
     if (entry.kind === "oversized") {
@@ -73,12 +75,21 @@ export async function classifyAndAnalyseSmall(input: ClassifyPhaseInput): Promis
       continue;
     }
 
+    const fileContent = entry.content;
+    const filePath = entry.relativePath;
     pending.push(
       limit(async () => {
         try {
           throwIfCancelled(input.knowledgeId);
           const condensed = await analyseScannedFile(input.analyzer, entry);
           await saveCondensed(input.metaPaths, condensed);
+          if (input.archiveSink !== undefined) {
+            await input.archiveSink.push({
+              knowledgeId: input.knowledgeId,
+              relativePath: filePath,
+              content: fileContent,
+            });
+          }
           smallFilesAnalysed += 1;
         } catch (cause: unknown) {
           if (cause instanceof CancellationError) {

--- a/packages/ingest-github/src/strategies/flat-folder/phases/process-big-files.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/process-big-files.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
-import { readFile } from "node:fs/promises";
 import { logger } from "@bb/logger";
 import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { SourceReader } from "src/types/pipeline.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
 import { readBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
 import { inspect } from "src/strategies/flat-folder/big-file/cache.ts";
@@ -9,7 +8,7 @@ import { processBigFile } from "src/strategies/flat-folder/big-file/index.ts";
 
 export interface ProcessBigFilesInput {
   knowledgeId: string;
-  repoDir: string;
+  source: SourceReader;
   metaPaths: MetaPaths;
 }
 
@@ -38,13 +37,17 @@ export async function processBigFilesQueue(input: ProcessBigFilesInput): Promise
       cached += 1;
       continue;
     }
-    const absolutePath = path.join(input.repoDir, entry.relativePath);
     let content: string;
     try {
-      content = await readFile(absolutePath, "utf8");
+      content = await input.source.readFile(entry.relativePath);
     } catch (cause: unknown) {
       failed += 1;
       logger.warn(`phase2: read failed for ${entry.relativePath}: ${describe(cause)}`);
+      continue;
+    }
+    if (content.length === 0) {
+      failed += 1;
+      logger.warn(`phase2: empty content for ${entry.relativePath}; skipping`);
       continue;
     }
     try {

--- a/packages/ingest-github/src/strategies/flat-folder/store-pull.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/store-pull.ts
@@ -1,0 +1,211 @@
+import { readFile } from "node:fs/promises";
+import { logger } from "@bb/logger";
+import {
+  deleteFileNodes,
+  ensureFlatFolderIndexes,
+  upsertFileNode,
+  upsertFolderNode,
+  upsertRepoNode,
+  type NodeScope,
+} from "@bb/neo4j";
+import { deleteRawFiles } from "@bb/mongo";
+import type { GithubIndexPayload } from "@bb/types";
+import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { CondensedFileAnalysis } from "src/types/condensed-file-analysis.ts";
+import { throwIfCancelled } from "src/pipeline/cancellation.ts";
+import type { DiffResult } from "src/pipeline/git-diff.ts";
+import { readCondensed } from "src/strategies/flat-folder/big-file/storage.ts";
+import { iterateFolderSummaries } from "src/strategies/flat-folder/folder-summary.ts";
+import { directFolderOf } from "src/strategies/flat-folder/folder-path.ts";
+import { languageFromPath } from "src/adapters/llm-file-analyzer.ts";
+import type { FolderSummary, RepoSummary, RepoSummaryEnvelope } from "src/strategies/flat-folder/types.ts";
+
+export interface StorePullInput {
+  scope: NodeScope;
+  payload: GithubIndexPayload;
+  branch: string;
+  metaPaths: MetaPaths;
+  diff: DiffResult;
+  affectedFolders: Set<string>;
+}
+
+export interface StorePullResult {
+  filesUpserted: number;
+  filesDeleted: number;
+  foldersUpserted: number;
+  repoUpserted: boolean;
+}
+
+/**
+ * Pull-time graph store. Mirrors the structure of `storeFlatAnalysis` but
+ * applies only the changes the diff specified:
+ *
+ * 1. Delete `:File` + Mongo rows for deleted + renamed-from paths.
+ * 2. Upsert `:File` nodes for added + modified + renamed-to paths.
+ * 3. Upsert affected `:Folder` nodes from the freshly-written folder
+ *    summaries on disk.
+ * 4. Upsert the `:Repo` node with the new repo summary.
+ *
+ * Untouched paths and unaffected folders are not modified.
+ */
+export async function storePullAnalysis(input: StorePullInput): Promise<StorePullResult> {
+  throwIfCancelled(input.scope.knowledgeId);
+  await ensureFlatFolderIndexes();
+
+  let filesUpserted = 0;
+  let filesDeleted = 0;
+  let foldersUpserted = 0;
+
+  const deletedPaths: string[] = [...input.diff.deleted, ...input.diff.renamed.map((r) => r.oldPath)];
+  if (deletedPaths.length > 0) {
+    await deleteFileNodes(input.scope.knowledgeId, deletedPaths);
+    await deleteRawFiles(input.scope.knowledgeId, deletedPaths);
+    filesDeleted = deletedPaths.length;
+  }
+
+  const repoSummary = await readRepoSummary(input.metaPaths);
+  let repoUpserted = false;
+  if (repoSummary !== null) {
+    await upsertRepoNode({
+      scope: input.scope,
+      repoUrl: input.payload.repoUrl,
+      branch: input.branch,
+      summary: {
+        purpose: repoSummary.purpose,
+        summary: repoSummary.summary,
+        keywords: repoSummary.keywords,
+        architecture: repoSummary.architecture,
+        dataFlow: repoSummary.dataFlow,
+        majorSubsystems: repoSummary.majorSubsystems,
+        keyPatterns: repoSummary.keyPatterns,
+      },
+    });
+    repoUpserted = true;
+  } else {
+    logger.warn(`pull-store: no repo summary on disk; skipping :Repo upsert`);
+  }
+
+  const folderPaths = new Set<string>();
+  for await (const folder of iterateFolderSummaries(input.metaPaths)) {
+    throwIfCancelled(input.scope.knowledgeId);
+    if (!input.affectedFolders.has(folder.folderPath)) {
+      continue;
+    }
+    await upsertFolderNode({
+      scope: input.scope,
+      folderPath: folder.folderPath,
+      summary: shapeFolderPayload(folder),
+    });
+    folderPaths.add(folder.folderPath);
+    foldersUpserted += 1;
+  }
+
+  const upsertPaths: string[] = [
+    ...input.diff.added,
+    ...input.diff.modified,
+    ...input.diff.renamed.map((r) => r.newPath),
+  ];
+  const seen = new Set<string>();
+  for (const relativePath of upsertPaths) {
+    if (seen.has(relativePath)) {
+      continue;
+    }
+    seen.add(relativePath);
+    throwIfCancelled(input.scope.knowledgeId);
+
+    const condensed = await readCondensed(input.metaPaths, relativePath);
+    if (condensed === null) {
+      logger.warn(`pull-store: condensed analysis missing for ${relativePath}; skipping file upsert`);
+      continue;
+    }
+
+    const folderPath = directFolderOf(relativePath);
+    if (!folderPaths.has(folderPath)) {
+      await upsertFolderNode({
+        scope: input.scope,
+        folderPath,
+        summary: emptyFolderPayload(),
+      });
+      folderPaths.add(folderPath);
+      foldersUpserted += 1;
+    }
+
+    await upsertFileNodeFromCondensed(input.scope, folderPath, condensed);
+    filesUpserted += 1;
+  }
+
+  logger.info(
+    `pull-store done: filesUpserted=${filesUpserted} filesDeleted=${filesDeleted} foldersUpserted=${foldersUpserted} repoUpserted=${repoUpserted}`,
+  );
+  return { filesUpserted, filesDeleted, foldersUpserted, repoUpserted };
+}
+
+async function upsertFileNodeFromCondensed(
+  scope: NodeScope,
+  folderPath: string,
+  file: CondensedFileAnalysis,
+): Promise<void> {
+  await upsertFileNode({
+    orgId: scope.orgId,
+    knowledgeId: scope.knowledgeId,
+    repoId: scope.repoId,
+    relativePath: file.relativePath,
+    folderPath,
+    language: file.language.length > 0 ? file.language : languageFromPath(file.relativePath),
+    sha: file.sha256,
+    sizeBytes: file.sizeBytes,
+    analysis: file.analysis,
+    isBigFile: file.isBigFile,
+    totalChunks: file.totalChunks,
+    totalTokenCount: file.totalTokenCount,
+  });
+}
+
+function shapeFolderPayload(folder: FolderSummary): {
+  purpose: string;
+  summary: string;
+  keywords: string[];
+  classes: string[];
+  functions: string[];
+  importsInternal: string[];
+  importsExternal: string[];
+  dependencyGraph: string;
+} {
+  return {
+    purpose: folder.purpose,
+    summary: folder.summary,
+    keywords: folder.keywords,
+    classes: folder.classes,
+    functions: folder.functions,
+    importsInternal: folder.importsInternal,
+    importsExternal: folder.importsExternal,
+    dependencyGraph: folder.dependencyGraph,
+  };
+}
+
+function emptyFolderPayload(): ReturnType<typeof shapeFolderPayload> {
+  return {
+    purpose: "",
+    summary: "",
+    keywords: [],
+    classes: [],
+    functions: [],
+    importsInternal: [],
+    importsExternal: [],
+    dependencyGraph: "",
+  };
+}
+
+async function readRepoSummary(metaPaths: MetaPaths): Promise<RepoSummary | null> {
+  try {
+    const raw = await readFile(metaPaths.repoSummaryJson, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+    const envelope = parsed as RepoSummaryEnvelope;
+    return envelope.repoSummary ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/ingest-github/src/types/context.md
+++ b/packages/ingest-github/src/types/context.md
@@ -14,7 +14,13 @@ Domain (sub-folder of `@bb/ingest-github`).
 - `pipeline.ts` — `ScannedFile`, `OversizedFile`, `ScanEntry`, `FileAnalyzer`
   port, `AnalyzedFileResult`, `PipelineDeps`, `PipelineSummary`,
   `SkipDecider` / `SkipDeciderInput` / `SkipDecision` (the unknown-extension
-  gate port; implementation lives under `pipeline/skip-decisions/`).
+  gate port; implementation lives under `pipeline/skip-decisions/`),
+  `SourceReader` / `ScanDeps` (the repository-read abstraction; default
+  implementation in `pipeline/disk-source-reader.ts`), `ArchiveSink` /
+  `ArchiveSinkInput` (an optional non-fatal sink that the open-source
+  binary never calls), and `SourceFactory` / `SourceFactoryInput` /
+  `SourceFactoryResult` (the optional injection hook surfaced through
+  `registerGithubWorkers`; see `docs/extension-points.md`).
 - `meta-paths.ts` — `MetaPaths` shape (`~/.bytebell/repos/.meta/<knowledgeId>/...`).
 - `file-analysis.ts` — `FALLBACK_LANGUAGE = "unknown"` and `emptyFileAnalysis()`
   factory. Both consumed by the LLM adapter and the big-file condenser.

--- a/packages/ingest-github/src/types/index.ts
+++ b/packages/ingest-github/src/types/index.ts
@@ -10,6 +10,13 @@ export type {
   SkipDecider,
   SkipDeciderInput,
   SkipDecision,
+  SourceReader,
+  ScanDeps,
+  ArchiveSink,
+  ArchiveSinkInput,
+  SourceFactory,
+  SourceFactoryInput,
+  SourceFactoryResult,
 } from "./pipeline.ts";
 export type { MetaPaths } from "./meta-paths.ts";
 export type { CondensedFileAnalysis } from "./condensed-file-analysis.ts";

--- a/packages/ingest-github/src/types/pipeline.ts
+++ b/packages/ingest-github/src/types/pipeline.ts
@@ -1,3 +1,4 @@
+import type { GithubIndexPayload } from "@bb/types";
 import type { FileAnalysis } from "@bb/mongo";
 
 export interface ScannedFile {
@@ -38,12 +39,63 @@ export interface PipelineDeps {
   reposRootDir: string;
 }
 
+export interface ScanDeps {
+  skipDecider?: SkipDecider;
+}
+
+export interface SourceReader {
+  /** Iterate every scannable file in the repo, yielding ScanEntry. */
+  scan(deps?: ScanDeps): AsyncGenerator<ScanEntry>;
+
+  /** Read a single file by repo-relative path. Used by the big-file phase. */
+  readFile(relativePath: string): Promise<string>;
+
+  /** The resolved HEAD commit hash. Populated by the time the reader is returned. */
+  readonly commitHash: string;
+
+  /** A stable on-disk path for the cloned tree when the reader is disk-backed; `""` otherwise. */
+  readonly localRepoDir: string;
+}
+
+export interface ArchiveSinkInput {
+  knowledgeId: string;
+  relativePath: string;
+  content: string;
+}
+
+export interface ArchiveSink {
+  /** Push a single file's content to an external store. Failures are non-fatal. */
+  push(input: ArchiveSinkInput): Promise<void>;
+}
+
+export interface SourceFactoryInput {
+  knowledgeId: string;
+  payload: GithubIndexPayload;
+  branch: string;
+}
+
+export interface SourceFactoryResult {
+  source: SourceReader;
+  commitHash: string;
+  archiveSink?: ArchiveSink;
+}
+
+/**
+ * Optional injection hook used by `registerGithubWorkers`. When provided, the
+ * runner skips the default disk clone and uses the returned reader instead.
+ * The hook is intentionally generic — it names a seam, not any specific
+ * alternative implementation. See `docs/extension-points.md`.
+ */
+export type SourceFactory = (input: SourceFactoryInput) => Promise<SourceFactoryResult>;
+
 export type SkipDecision = "accept" | "reject-static" | "reject-llm" | "accept-llm";
 
 export interface SkipDeciderInput {
   relativePath: string;
   absolutePath: string;
   ext: string;
+  /** Pre-loaded content. When set, the LLM branch uses this instead of reading absolutePath from disk. */
+  content?: string;
 }
 
 export interface SkipDecider {

--- a/packages/ingest-github/src/types/strategy.ts
+++ b/packages/ingest-github/src/types/strategy.ts
@@ -1,5 +1,6 @@
 import type { GithubIndexPayload } from "@bb/types";
 import type { MetaPaths } from "./meta-paths.ts";
+import type { ArchiveSink, SourceReader } from "./pipeline.ts";
 
 export interface StrategyContext {
   knowledgeId: string;
@@ -10,7 +11,8 @@ export interface StrategyContext {
 export interface StrategyInput {
   payload: GithubIndexPayload;
   branch: string;
-  repoDir: string;
+  source: SourceReader;
+  archiveSink?: ArchiveSink;
   metaPaths: MetaPaths;
   context: StrategyContext;
 }

--- a/packages/ingest-github/tsconfig.json
+++ b/packages/ingest-github/tsconfig.json
@@ -3,9 +3,13 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "baseUrl": ".",
     "paths": {
       "src/*": ["./src/*"]
-    }
+    },
+    "ignoreDeprecations": "5.0",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*", "src/**/*.json"]
 }

--- a/packages/logger/src/dirs.ts
+++ b/packages/logger/src/dirs.ts
@@ -1,11 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getBytebellHome } from "@bb/config";
+import { getBytebellHome, isDevMode } from "@bb/config";
 
 const LOGS_DIR_NAME = "logs";
 const DIR_MODE = 0o700;
 
+/**
+ * Resolves the directory log files are written to. In dev mode
+ * (`BYTEBELL_DEV=1`) this is `<cwd>/logs/`, so contributors can tail logs
+ * from the project they're working in. Otherwise the canonical
+ * `~/.bytebell/logs/` is used. The CLI's server-spawn redirect honors the
+ * same toggle, so both Winston output and bun stdout/stderr land together.
+ */
 export function getLogsDir(): string {
+  if (isDevMode()) {
+    return path.join(process.cwd(), LOGS_DIR_NAME);
+  }
   return path.join(getBytebellHome(), LOGS_DIR_NAME);
 }
 

--- a/packages/server/src/githubCommitsRoute.ts
+++ b/packages/server/src/githubCommitsRoute.ts
@@ -1,40 +1,33 @@
 import type { Request, Response, Router } from "express";
 import express from "express";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import path from "node:path";
-import { stat } from "node:fs/promises";
 import { getKnowledge } from "@bb/mongo";
-import { getBytebellHome } from "@bb/config";
-
-const exec = promisify(execFile);
+import { fetchRecentCommits } from "@bb/ingest-github";
 
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 2000;
 
-interface CommitEntry {
-  hash: string;
-  shortHash: string;
-  subject: string;
-  author: string;
-  date: string;
-}
-
 interface CommitsResponse {
   knowledgeId: string;
   branch: string;
-  commits: CommitEntry[];
+  commits: Array<{
+    hash: string;
+    shortHash: string;
+    subject: string;
+    author: string;
+    date: string;
+  }>;
 }
 
 /**
  * `GET /api/v1/github/:knowledgeId/commits?limit=N` — return the most recent
- * N commits on the indexed branch's history from the local clone. Used by the
- * CLI commit picker so the user can target any commit in `bytebell pull`.
+ * N commits on the indexed branch via GitHub's REST API.
  *
- * Reads from the local clone at `~/.bytebell/repos/<knowledgeId>`. Runs
- * `git fetch origin <branch>` first so the local refs are up to date with
- * whatever has been pushed since the last ingest. Then runs
- * `git log origin/<branch> -n <limit>` with a stable separator format.
+ * Reads `Authorization: Bearer <pat>` if the client supplies one. Public
+ * repos work unauthenticated; private repos answer 404 until a token is
+ * provided, at which point the CLI re-requests with auth.
+ *
+ * Local clone state is intentionally not consulted — the picker should
+ * work even if the clone is shallow, stale, or missing.
  */
 export function buildGithubCommitsRoute(): Router {
   const router = express.Router();
@@ -59,66 +52,34 @@ export function buildGithubCommitsRoute(): Router {
       return;
     }
     const branch = knowledge.source.branch ?? "main";
-    const repoDir = path.join(getBytebellHome(), "repos", knowledgeId);
+    const gitToken = extractBearerToken(req.headers["authorization"]);
 
-    try {
-      await stat(path.join(repoDir, ".git"));
-    } catch {
-      res.status(404).json({ error: "local clone not found; re-index the knowledge to recreate it" });
-      return;
-    }
-
-    try {
-      await exec("git", ["-C", repoDir, "fetch", "origin", branch], { timeout: 30_000 });
-    } catch {
-      // Non-fatal: proceed with whatever the local clone has.
-    }
-
-    let stdout: string;
-    try {
-      const result = await exec(
-        "git",
-        [
-          "-C",
-          repoDir,
-          "log",
-          `origin/${branch}`,
-          `--max-count=${limit}`,
-          "--pretty=format:%H%x1f%h%x1f%s%x1f%an%x1f%aI",
-        ],
-        { maxBuffer: 16 * 1024 * 1024 },
-      );
-      stdout = result.stdout;
-    } catch (cause: unknown) {
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      res.status(500).json({ error: `git log failed: ${msg}` });
-      return;
-    }
-
-    const commits: CommitEntry[] = [];
-    for (const line of stdout.split("\n")) {
-      if (line.length === 0) {
-        continue;
+    const result = await fetchRecentCommits(knowledge.source.repoUrl, branch, limit, gitToken);
+    switch (result.status) {
+      case "ok": {
+        const payload: CommitsResponse = { knowledgeId, branch, commits: result.commits };
+        res.status(200).json(payload);
+        return;
       }
-      const parts = line.split("\x1f");
-      const hash = parts[0];
-      const shortHash = parts[1];
-      const subject = parts[2];
-      const author = parts[3];
-      const date = parts[4];
-      if (
-        hash === undefined ||
-        shortHash === undefined ||
-        subject === undefined ||
-        author === undefined ||
-        date === undefined
-      ) {
-        continue;
+      case "not_found": {
+        res
+          .status(404)
+          .json({ error: "repo not found or private; supply a github token via Authorization: Bearer <pat>" });
+        return;
       }
-      commits.push({ hash, shortHash, subject, author, date });
+      case "unauthorized": {
+        res.status(401).json({ error: "github token rejected" });
+        return;
+      }
+      case "rate_limited": {
+        res.status(429).json({ error: "github rate limit reached; retry later or supply a token" });
+        return;
+      }
+      case "error": {
+        res.status(502).json({ error: result.message });
+        return;
+      }
     }
-    const payload: CommitsResponse = { knowledgeId, branch, commits };
-    res.status(200).json(payload);
   });
   return router;
 }
@@ -132,4 +93,17 @@ function parseLimit(raw: string | undefined): number {
     return DEFAULT_LIMIT;
   }
   return Math.min(n, MAX_LIMIT);
+}
+
+function extractBearerToken(header: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const match = /^Bearer\s+(.+)$/iu.exec(raw.trim());
+  if (match === null) {
+    return undefined;
+  }
+  const token = match[1]?.trim();
+  return token !== undefined && token.length > 0 ? token : undefined;
 }

--- a/packages/server/src/githubCommitsRoute.ts
+++ b/packages/server/src/githubCommitsRoute.ts
@@ -1,0 +1,135 @@
+import type { Request, Response, Router } from "express";
+import express from "express";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { stat } from "node:fs/promises";
+import { getKnowledge } from "@bb/mongo";
+import { getBytebellHome } from "@bb/config";
+
+const exec = promisify(execFile);
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 2000;
+
+interface CommitEntry {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+
+interface CommitsResponse {
+  knowledgeId: string;
+  branch: string;
+  commits: CommitEntry[];
+}
+
+/**
+ * `GET /api/v1/github/:knowledgeId/commits?limit=N` — return the most recent
+ * N commits on the indexed branch's history from the local clone. Used by the
+ * CLI commit picker so the user can target any commit in `bytebell pull`.
+ *
+ * Reads from the local clone at `~/.bytebell/repos/<knowledgeId>`. Runs
+ * `git fetch origin <branch>` first so the local refs are up to date with
+ * whatever has been pushed since the last ingest. Then runs
+ * `git log origin/<branch> -n <limit>` with a stable separator format.
+ */
+export function buildGithubCommitsRoute(): Router {
+  const router = express.Router();
+  router.get("/api/v1/github/:knowledgeId/commits", async (req: Request, res: Response) => {
+    const knowledgeId = req.params["knowledgeId"];
+    if (typeof knowledgeId !== "string" || knowledgeId.length === 0) {
+      res.status(400).json({ error: "knowledgeId required" });
+      return;
+    }
+    const limitRaw = req.query["limit"];
+    const limit = parseLimit(typeof limitRaw === "string" ? limitRaw : undefined);
+
+    const knowledge = await getKnowledge(knowledgeId);
+    if (knowledge === null) {
+      res.status(404).json({ error: "knowledge not found" });
+      return;
+    }
+    if (knowledge.source.kind !== "github") {
+      res
+        .status(422)
+        .json({ error: `commits endpoint is only supported for github knowledge (kind=${knowledge.source.kind})` });
+      return;
+    }
+    const branch = knowledge.source.branch ?? "main";
+    const repoDir = path.join(getBytebellHome(), "repos", knowledgeId);
+
+    try {
+      await stat(path.join(repoDir, ".git"));
+    } catch {
+      res.status(404).json({ error: "local clone not found; re-index the knowledge to recreate it" });
+      return;
+    }
+
+    try {
+      await exec("git", ["-C", repoDir, "fetch", "origin", branch], { timeout: 30_000 });
+    } catch {
+      // Non-fatal: proceed with whatever the local clone has.
+    }
+
+    let stdout: string;
+    try {
+      const result = await exec(
+        "git",
+        [
+          "-C",
+          repoDir,
+          "log",
+          `origin/${branch}`,
+          `--max-count=${limit}`,
+          "--pretty=format:%H%x1f%h%x1f%s%x1f%an%x1f%aI",
+        ],
+        { maxBuffer: 16 * 1024 * 1024 },
+      );
+      stdout = result.stdout;
+    } catch (cause: unknown) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      res.status(500).json({ error: `git log failed: ${msg}` });
+      return;
+    }
+
+    const commits: CommitEntry[] = [];
+    for (const line of stdout.split("\n")) {
+      if (line.length === 0) {
+        continue;
+      }
+      const parts = line.split("\x1f");
+      const hash = parts[0];
+      const shortHash = parts[1];
+      const subject = parts[2];
+      const author = parts[3];
+      const date = parts[4];
+      if (
+        hash === undefined ||
+        shortHash === undefined ||
+        subject === undefined ||
+        author === undefined ||
+        date === undefined
+      ) {
+        continue;
+      }
+      commits.push({ hash, shortHash, subject, author, date });
+    }
+    const payload: CommitsResponse = { knowledgeId, branch, commits };
+    res.status(200).json(payload);
+  });
+  return router;
+}
+
+function parseLimit(raw: string | undefined): number {
+  if (raw === undefined) {
+    return DEFAULT_LIMIT;
+  }
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(n, MAX_LIMIT);
+}

--- a/packages/server/src/githubPullRoute.ts
+++ b/packages/server/src/githubPullRoute.ts
@@ -6,7 +6,7 @@ import { fetchLatestCommitHash } from "@bb/ingest-github";
 
 interface PullBody {
   knowledgeId?: unknown;
-  latestCommitHash?: unknown;
+  targetCommitHash?: unknown;
   gitToken?: unknown;
 }
 
@@ -17,15 +17,21 @@ interface PullResponse {
   commitHash?: string;
 }
 
+const COMMIT_HASH_RE = /^[0-9a-f]{40}$/u;
+
 /**
- * `POST /api/v1/github/pull` — re-index a previously added GitHub repo at the
- * branch's current HEAD.
+ * `POST /api/v1/github/pull` — re-index a github knowledge to a specific commit
+ * reachable from its indexed branch. When the caller omits `targetCommitHash`,
+ * the route resolves the branch's HEAD via the GitHub API as a best-effort
+ * pre-enqueue convenience. The worker repeats the resolution after clone as
+ * the canonical guard.
  *
- * Pre-fetches HEAD via the GitHub REST API when the caller doesn't supply
- * `latestCommitHash`. If that resolved SHA is already in the recorded
- * `commitHashes`, returns `{ noOp: true }` without enqueueing — the worker's
- * own idempotency check is the canonical guard, but bailing here saves a
- * round-trip through the queue.
+ * Direction does not matter — forward (catch-up), backward (rollback), and
+ * sideways (any commit on the same branch) all run the same orchestrator.
+ * Cross-branch pulls are rejected at the worker; the caller must create a
+ * fresh github_index job to switch branches.
+ *
+ * See `docs/pull-plan.md` for the full pipeline description.
  */
 export function buildGithubPullRoute(): Router {
   const router = express.Router();
@@ -36,9 +42,17 @@ export function buildGithubPullRoute(): Router {
       return;
     }
     const knowledgeId = body.knowledgeId;
+
     const gitToken = typeof body.gitToken === "string" && body.gitToken.length > 0 ? body.gitToken : undefined;
-    const suppliedCommit =
-      typeof body.latestCommitHash === "string" && body.latestCommitHash.length > 0 ? body.latestCommitHash : undefined;
+    const suppliedTarget =
+      typeof body.targetCommitHash === "string" && body.targetCommitHash.length > 0 ? body.targetCommitHash : undefined;
+    if (suppliedTarget !== undefined && !COMMIT_HASH_RE.test(suppliedTarget)) {
+      res.status(400).json({
+        error: "invalid targetCommitHash",
+        message: "targetCommitHash must be a 40-character hex SHA",
+      });
+      return;
+    }
 
     const knowledge = await getKnowledge(knowledgeId);
     if (knowledge === null) {
@@ -49,27 +63,41 @@ export function buildGithubPullRoute(): Router {
       res.status(422).json({ error: `pull is only supported for github knowledge (kind=${knowledge.source.kind})` });
       return;
     }
+    if (knowledge.source.commitId === undefined || knowledge.source.commitId.length === 0) {
+      res.status(422).json({
+        error: "knowledge not yet indexed",
+        message: "pull requires a previously-indexed commit; this knowledge has no commitId. Run github_index first.",
+      });
+      return;
+    }
 
-    // Pre-fetch HEAD when the caller didn't supply one — best-effort, null on
-    // transient API failure. Worker reads `git rev-parse HEAD` after clone for
-    // the authoritative answer regardless.
     const branch = knowledge.source.branch ?? "main";
-    const targetCommit =
-      suppliedCommit ?? (await fetchLatestCommitHash(knowledge.source.repoUrl, branch, gitToken)) ?? undefined;
+    let targetCommit = suppliedTarget;
+    if (targetCommit === undefined) {
+      try {
+        const head = await fetchLatestCommitHash(knowledge.source.repoUrl, branch, gitToken);
+        if (head !== null && COMMIT_HASH_RE.test(head)) {
+          targetCommit = head;
+        }
+      } catch {
+        // Transient API failure; leave target unset and let the worker resolve via git rev-parse.
+      }
+    }
 
-    // Early idempotency — skip enqueue when already at this commit.
-    const recorded = knowledge.source.commitHashes ?? [];
-    if (targetCommit !== undefined && recorded.includes(targetCommit)) {
+    if (targetCommit !== undefined && targetCommit === knowledge.source.commitId) {
       const response: PullResponse = { knowledgeId, noOp: true, commitHash: targetCommit };
       res.status(200).json(response);
       return;
     }
 
-    const jobId = await enqueueGithubPull({
-      knowledgeId,
-      ...(targetCommit !== undefined ? { latestCommitHash: targetCommit } : {}),
-      ...(gitToken !== undefined ? { gitToken } : {}),
-    });
+    const payload: { knowledgeId: string; targetCommitHash?: string; gitToken?: string } = { knowledgeId };
+    if (targetCommit !== undefined) {
+      payload.targetCommitHash = targetCommit;
+    }
+    if (gitToken !== undefined) {
+      payload.gitToken = gitToken;
+    }
+    const jobId = await enqueueGithubPull(payload);
     const response: PullResponse = {
       knowledgeId,
       jobId,

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -3,6 +3,7 @@ import { mountMcp } from "@bb/mcp";
 import { buildHealthRoute } from "./healthRoute.ts";
 import { buildGithubIndexRoute } from "./githubIndexRoute.ts";
 import { buildGithubPullRoute } from "./githubPullRoute.ts";
+import { buildGithubCommitsRoute } from "./githubCommitsRoute.ts";
 import { buildLocalIndexRoute } from "./localIndexRoute.ts";
 import { buildReposRoute } from "./reposRoute.ts";
 import { buildDeleteRoute } from "./deleteRoute.ts";
@@ -13,6 +14,7 @@ export function registerRoutes(app: Application): void {
   app.use(buildHealthRoute());
   app.use(buildGithubIndexRoute());
   app.use(buildGithubPullRoute());
+  app.use(buildGithubCommitsRoute());
   app.use(buildLocalIndexRoute());
   app.use(buildReposRoute());
   app.use(buildDeleteRoute());

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "./src",
     "outDir": "./dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../ingest-github" }]
 }

--- a/packages/types/context.md
+++ b/packages/types/context.md
@@ -35,7 +35,7 @@ enum Config { ... }
 enum JobType     { GithubIndex, GithubPull }
 enum JobPriority { Low, Normal, High }
 interface GithubIndexPayload { knowledgeId, repoUrl, branch?, commitHash?, gitToken? }
-interface GithubPullPayload  { knowledgeId, latestCommitHash?, isShallow, gitToken? }
+interface GithubPullPayload  { knowledgeId, targetCommitHash?, gitToken? }
 interface JobMessage<P>      { id, type, priority, knowledgeId, attempt, createdAt, payload }
 type      PayloadFor<T extends JobType>
 

--- a/packages/types/src/job.ts
+++ b/packages/types/src/job.ts
@@ -22,11 +22,13 @@ export interface GithubIndexPayload {
 export interface GithubPullPayload {
   knowledgeId: string;
   /**
-   * Optional anchor for the commit the caller already resolved (CLI / route may pre-fetch HEAD).
-   * The worker reads `git rev-parse HEAD` after clone regardless, but this field lets early
-   * idempotency checks short-circuit before enqueue when the caller already knows HEAD.
+   * Optional commit to re-index the knowledge to. Must be a 40-character hex SHA
+   * and must be reachable from `origin/<knowledge.branch>`. When omitted, the
+   * worker resolves the branch's HEAD after clone. Direction does not matter —
+   * the orchestrator handles forward, backward, and sideways targets through
+   * the same diff machinery. See `docs/pull-plan.md`.
    */
-  latestCommitHash?: string;
+  targetCommitHash?: string;
   gitToken?: string;
 }
 


### PR DESCRIPTION
## What changed

### `bytebell pull` — incremental re-ingest of changed files
- New `github_pull` worker that diffs `currentCommit → targetCommit` and re-analyses only changed paths instead of re-walking the whole tree.
  - `packages/ingest-github/src/pipeline/pull.ts` (orchestrator), `pull-diff-resolver.ts` (deepen + diff), `git-diff.ts` (low-level git helpers), `affected-folders.ts` (folder set), `strategies/flat-folder/analyse-changed.ts` (per-file dispatcher), `strategies/flat-folder/folder-summary-selective.ts` (re-summarise touched folders only), `strategies/flat-folder/store-pull.ts` (graph upsert/delete diff).
- Server route `POST /api/v1/github/pull` accepts `{ knowledgeId, targetCommitHash?, gitToken? }`.
- CLI `bytebell pull [knowledge-id]` with interactive repo picker, latest-vs-specific-commit mode, and per-job progress polling.
- Shallow clones are deepened on-demand (`--deepen=50` → `--deepen=200`) before the reachability check, so any commit within the picker's window is pull-able.

### Commit picker — GitHub API instead of `git log`
- New `GET /api/v1/github/:knowledgeId/commits` calls GitHub REST and returns up to 200 (max 2000) commits, paginated.
- Drops the previous shell-out to `git log` on the local clone, which only ever returned the shallow tip.
- Private-repo handling: route returns 404 unauthenticated; CLI catches it, renders a masked `TokenPrompt`, retries once, then forwards the PAT to the pull job. One-shot retry — no infinite loop on bad tokens.
- `Authorization: Bearer <pat>` header (not URL query) so tokens don't land in server access logs.
- `Field.tsx` gained an `autoFocus` prop so the single-field token prompt accepts input without a Tab cycle.

### Dev mode — logs to `<cwd>/logs/`
- `BYTEBELL_DEV=1` env var redirects both Winston output and the CLI's spawned-server stdio to `<cwd>/logs/` instead of `~/.bytebell/logs/`. Tail-from-the-repo workflow during contributor work.
- `BootCommand` prints `dev mode: logs → <cwd>/logs/` so it's discoverable, and warns when the env var is set but the running server was spawned without it (toggle requires a server restart).

### Supporting refactors
- **Source reader abstraction** — `SourceReader` / `SourceFactory` interface (`packages/ingest-github/src/types/pipeline.ts`), `disk-source-reader.ts` default impl. Replaces direct `fs.readdir`/`readFile` calls in the scan and big-file phases so the strategy is independent of where files come from.
- **LLM skip-decision gate** — opt-in cache-backed LLM gate in `skip-decisions/decider.ts` for deciding which files are worth analysing (config-gated; off by default).
- **Concurrency knobs** — new config keys for `concurrent_workers`, `context_window_limit`, `big_file_line_threshold`, `absolute_file_size_cap` (`packages/config/src/schema.ts`).
- **TS build fix** — `packages/ingest-github/tsconfig.json` now emits `.d.ts` (`noEmit: false`, `emitDeclarationOnly: true`, `baseUrl: "."`) so consumers compile against declarations instead of re-resolving `src/*` aliases. `packages/server/tsconfig.json` references it. Without this `bun run typecheck` failed at the root.

## Why

extended flat folder stratgey with the pull

The dev-mode flag was added so contributors can tail logs from the repo they're working in without `cd ~/.bytebell`. The TS build fix is a hard prerequisite — the `src/*` import convention in `@bb/ingest-github` was breaking root `tsc -b` once consumers (`@bb/server`) re-resolved its raw `.ts` sources.
