### PR TITLE
docs: detailed explanation of bytebell working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,66 @@
-# Bytebell
+# Bytebell [bytebell.ai]
 
-**A local knowledge graph for your codebase, served over MCP.**
+## What is this and why does it exist
 
-Bytebell indexes a repo into a Neo4j graph where every file node carries an LLM-generated `purpose`, `summary`, and `businessContext` — so Claude Code, Cursor, and other MCP-capable agents can answer questions about your code without reading the whole repo into context. All local. No telemetry. No auth.
+If you've ever worked on a codebase that spans multiple repositories, you already know the pain. You open up your copilot or your coding agent, you ask it something like "how does this authentication service in Repo A affect the user management flow in Repo B" and it just goes blank.
+
+It either hallucinates an answer or tells you it doesn't have enough context. And the thing is, its not the model's fault. The model is smart enough. The problem is that no tool in the current ecosystem gives it the right context to work with.
+
+Every code intelligence tool today, whether its vector search based like **claude-context** and **Cody**, or AST based like **Serena** and **code-graph-mcp**, or even production grade tools like **Sourcegraph** with **SCIP** indexing, they all do fundamentally the same thing.
+
+They read your code structurally. They parse syntax trees, they map function calls, they build embedding vectors. And all of that is useful to some degree but it completely misses the question that actually matters which is what is this code for. Not what it looks like syntactically, not what functions it calls, but what is its purpose, what business logic does it encode, why does it exist in the first place, and how does it connect to code in entirely different repositories that were written by entirely different teams.
+
+**ByteBell** takes a fundamentally different approach. Instead of parsing structure and hoping the model figures out meaning at query time, we run an LLM once at index time across your entire codebase. The LLM reads every file and extracts its **semantic purpose**, its **business role**, its **cross-repo dependencies**, what it does and why it does it. All of that understanding gets stored in a **persistent semantic graph** that lives across sessions, across models, across every copilot and agent you use. You pay the LLM cost once during indexing and then every tool in your stack benefits from that understanding forever.
+
+The key insight here is that every other tool in this space persists an index. ByteBell persists meaning. This is an architectural difference that changes everything downstream.
+
+## How it actually works
+
+When you point ByteBell at your repositories, it does a one time semantic indexing pass. For every file, it sends the code to an LLM with a carefully designed prompt that asks it to extract several things: what does this file do in plain english, what business domain does it belong to, how does it relate to other files in this repo and in other repos, what would break if you changed it, and what is the intent behind the key functions and classes.
+All of these semantic annotations get stored in a graph database where the nodes are files, functions, and concepts, and the edges are semantic relationships like "this service depends on that authentication module for JWT validation" rather than just "this file imports that file." The difference is massive because when a model later queries this graph it gets back actual understanding, not just a list of files that look syntactically similar to the query.
+The graph is persistent and shared. It doesn't disappear when your session ends. It doesn't get rebuilt every time you switch from one copilot to another. Whether you're using Claude, or GPT, or an open source model, or switching between Cursor and Windsurf and Claude Code, they all read from the same semantic graph. Your codebase understanding is decoupled from any single tool or model.
+
+## The cost problem and how we solved it
+
+The obvious objection to using LLMs for indexing is cost. If you're running Claude Opus on every file in a large codebase you'll burn through thousands of dollars before you even start working. So we did something that nobody else has done properly, we ran a systematic benchmark across 14 different models to find the sweet spot between accuracy and cost.
+We tested on 30 Kubernetes ecosystem files with roughly 33,800 average input tokens per file and 3,200 output tokens per file. We scored each model across 7 categories including search accuracy, graph quality, semantic understanding, cross-repo integration, section mapping, business context extraction, and JSON formatting. Any model that scored below 70 points was dropped as unusable regardless of how cheap it was.
+The results were surprising.
+DeepSeek V4 Flash can index 1,000 files at just $7.01 with an accuracy score of 71.13. Thats 100x cheaper than Claude Opus 4.7 at $752.70 and only about 2.3 points behind it in quality. GLM 5.1 sits in a nice balanced spot at $23.24 with 72.22 accuracy. Claude Sonnet 4.6 is the premium quality option at $149.40 with the highest accuracy at 73.56 if you need the absolute best analysis and dont mind paying for it.
+
+Models like GPT 5.4 scored 55.65 which is just completely unusable, and Step 3.5 Flash came in at 69.71 which is cheap but falls below our quality floor.
+
+So the default recommendation is DeepSeek V4 Flash for most use cases because it gives you production quality semantic indexing at a cost thats genuinely negligible even for very large codebases. You can always run a premium model like Sonnet on your most critical repositories if you want that extra 2 points of accuracy.
+
+## What we tested and what we found
+
+We ran ByteBell on the SWE-bench Verified benchmark, specifically on Astropy and OpenTelemetry which are the two most important repositories in that dataset, roughly 8 GB of code combined. We compared task performance with ByteBell's semantic context layer (MCP) versus raw model performance without it.
+
+The per-task results across 55 tasks show something that seems counterintuitive at first. ByteBell feeds the model 22 less context, the average cost per task is actually lower with ByteBell at $0.52 versus $0.73 without it.
+The reason is simple, when the model has real semantic understanding of the codebase it stops wasting tokens exploring dead ends, searching through irrelevant files, and guessing at relationships. It knows exactly where to look and what things mean. The result is 60% less cost and 80% faster responses with the same or better accuracy.
+
+But the really important finding was about cross-repository performance. We tested on 150,000+ files across 46 Kubernetes ecosystem repositories and in cross-repo scenarios, even SOTA models with their full prompt caching and claude.md configurations dont just perform poorly, they fail to complete the task entirely. They literally cannot finish. The model runs out of context, gets confused about which repo it's looking at, hallucinates connections that dont exist, and eventually gives up or produces garbage. ByteBell's persistent semantic graph is the only approach we've seen that gives the model enough cross-repo understanding to actually solve these problems end to end.
+
+## How ByteBell compares to existing tools
+
+We did a detailed comparison against the major tools in this space and the differences are architectural, not incremental.
+Vector search tools like claude-context and Cody embed your code into vector space and retrieve chunks that are semantically similar to your query. This works okay for simple "find code that looks like this" queries but it fundamentally treats code like english text which it is not.
+
+Code is logic with complex dependency chains, side effects, and implicit contracts that dont show up in embedding similarity. These tools also dont persist understanding across sessions and dont share context across different copilots.
+
+AST and LSP based tools like **Serena** and **code-graph-mcp** parse your code into abstract syntax trees and use language server protocols to map structural relationships. They know what calls what and what imports what but they have zero understanding of business intent. They can tell you that function A calls function B but they cannot tell you why that call exists or what business rule it implements. They also work within a single repository boundary and have no concept of cross-repo semantic connections.
+
+**GitNexus** builds a static AST graph which is essentially a more sophisticated version of the AST approach. It maps out structural relationships across your codebase in a graph format which is useful but again, its purely structural. It knows syntax, not semantics. And it doesn't persist any understanding across sessions.
+
+**Graphify** combines AST parsing with multimodal analysis so it tries to understand code through multiple representations beyond just the syntax tree. Its a step in the right direction but its still fundamentally building a structural graph enriched with pattern matching rather than extracting actual semantic intent. No cross-repo graph, no persistent meaning across sessions.
+
+**Sourcegraph** with **SCIP** indexing is probably the most production grade tool in this list and it does excellent structural code intelligence at scale. But SCIP is a structural indexing format, it gives you precise code navigation and cross-references but not semantic understanding. It also only partially supports cross-repo connections and doesn't share context across different copilots and agents.
+Augment is a cloud SaaS approach that does provide some cost reduction per query but it doesn't persist meaning across sessions, doesn't share across copilots, doesn't build a cross-repo semantic graph, and critically it cannot run on-prem or air-gapped which is a dealbreaker for many enterprises.
+
+**ByteBell** is the only tool that checks every box. Persistent semantic understanding across sessions, shared across every copilot and agent, one graph that works with every model, cross-repo semantic connections, business context per commit, fully on-prem and air-gapped capable, 80%+ cost reduction per query, and 20 to 40% accuracy improvement on cross-repo tasks.
+
+Based on what we've seen so far, we believe that open source models with access to ByteBell's semantic context layer can improve their performance by at least 10%-40% compared to current SOTA models running without it. The early results already point strongly in that direction but we need to prove it across the full dataset to make that claim definitively.
+
+If you can sponsor API credits on OpenRouter, OpenAI, or Anthropic, or if you know someone who can, please reach out. Every dollar goes directly into running benchmarks on the complete SWE-bench Verified dataset and we will publish all results openly. This is an open source project and the benchmark results will be open too.
 
 ## Quickstart
 


### PR DESCRIPTION
Title: [TEST] docs/readme-rewrite — expand README with positioning, benchmarks, and tool comparison

(Use [DONE] instead of [TEST] once reviewed.)

Description:


## What changed

- Rewrote `README.md` intro: replaced the single-tagline summary with a longer
  "What is this and why does it exist" narrative framing the cross-repo context
  problem.
- Added "How it actually works" section describing the one-time LLM semantic
  indexing pass and the persistent semantic graph model.
- Added "The cost problem and how we solved it" section with the 14-model
  benchmark results (DeepSeek V4 Flash $7.01/1k files, GLM 5.1 $23.24,
  Claude Sonnet 4.6 $149.40, Claude Opus 4.7 $752.70) and recommended default.
- Added "What we tested and what we found" section summarising the SWE-bench
  Verified results on Astropy + OpenTelemetry (~8 GB), and the 150k-file /
  46-repo Kubernetes cross-repo finding.
- Added "How ByteBell compares to existing tools" section contrasting against
  claude-context, Cody, Serena, code-graph-mcp, GitNexus, Graphify, Sourcegraph
  + SCIP, and Augment.
- Updated H1 from `# Bytebell` to `# Bytebell [bytebell.ai]`.
- Net +61 / −3 lines in `README.md`; no code, config, or package changes.

## Why

The previous README was a single-sentence pitch that didn't explain what makes
Bytebell architecturally different from existing code-intelligence tools, nor
did it surface the benchmark data that justifies the LLM-at-index-time approach.
New visitors landing on the repo couldn't tell why they should care or how it
compares to Sourcegraph / Serena / Cody, so the project was being mis-categorised
as "another vector-search MCP." This rewrite makes the positioning, the cost
story, and the cross-repo claim legible up front.

## How to test

This is a docs-only change — no runtime behaviour is affected.

1. `git fetch origin && git checkout fix/readme`
2. Open `README.md` in a Markdown previewer (or view on the PR page on GitHub).
3. Verify the new sections render correctly: headings, lists, and the inline
   benchmark numbers are readable; no broken links.
4. Run the project's format check to confirm the file is Prettier-clean:
bunx prettier --check README.md


Expected: `All matched files use Prettier code style!`
5. Confirm the rest of the README below the "Quickstart" heading is unchanged
vs. `main`:
git diff main -- README.md


Only the top section (lines 1–~66) should differ.

## Screenshots

N/A — docs-only change, no UI.
Checklist status:

 Branch name — fix/readme does not follow the guide (use docs/ prefix). Rename recommended.
 Title starts with status tag.
 Description has What / Why / How to test.
 No screenshots needed (no UI).
 CI — format check failed on your last push; rerun bun run scripts/push-validate.ts locally to confirm green before marking [DONE].
 Self-review the diff for typos (a few in the prose: "its" vs "it's", "dont" vs "don't", "thats" vs "that's") — worth a polish pass before [DONE].
 Rebase against main before merging.
