### PR TITLE
[TEST] feature/progress-factory — progress reporting extension port for flat-folder strategy

### DIFF
--- a/packages/ingest-github/README.md
+++ b/packages/ingest-github/README.md
@@ -50,7 +50,12 @@ The package does **not** own:
   strategies can add this)
 - Semantic chunking, big-file processing, smart sampling (future
   strategies)
-- Recovery / progress reporting / failed-files tracking
+- Recovery / failed-files tracking
+- Progress **transport** — the package now ships a `ProgressContext`
+  extension port under `src/progress/` (see that folder's README), but
+  the actual SSE / Pub-Sub plumbing lives in the host binary's progress
+  package. The OSS default (`nullProgressContextFactory`) discards every
+  event, consistent with the no-outbound-calls posture.
 - Provider abstraction (no Bitbucket support; GitHub-only)
 - Concurrency control (sequential per-file processing intentional for
   v0; revisit when users complain)
@@ -65,6 +70,7 @@ function registerLocalIngestWorker(): void; // wires LocalIngest
 interface RegisterGithubWorkersDeps {
   sourceFactory?: SourceFactory; // index-side hook
   pullFactory?: PullFactory; // pull-side hook (provides reader + diff + targetCommit)
+  progressContextFactory?: ProgressContextFactory; // SSE progress hook (default: no-op)
 }
 
 // Lower-level building blocks (downstream consumers with their own queue

--- a/packages/ingest-github/src/index.ts
+++ b/packages/ingest-github/src/index.ts
@@ -11,24 +11,30 @@ import {
   buildFileAnalysisUserPrompt,
 } from "./strategies/flat-folder/prompts/file-analysis.ts";
 import type { PullFactory, SourceFactory } from "./types/pipeline.ts";
+import type { ProgressContextFactory } from "./progress/types.ts";
+import { nullProgressContextFactory } from "./progress/NullProgressReporter.ts";
 
 /**
- * Optional dependencies for the GitHub workers. Both factories are
- * documented in `docs/extension-points.md`. The open-source binary
- * leaves both undefined — index and pull use the default disk-backed
- * readers and a local `git clone` / `git diff`.
+ * Optional dependencies for the GitHub workers. Factories are documented in
+ * `docs/extension-points.md`. The open-source binary leaves them undefined —
+ * index and pull use the default disk-backed readers, and progress events
+ * are discarded by `nullProgressContextFactory`.
  */
 export interface RegisterGithubWorkersDeps {
   sourceFactory?: SourceFactory;
   pullFactory?: PullFactory;
+  progressContextFactory?: ProgressContextFactory;
 }
 
-function buildRunner(sourceFactory: SourceFactory | undefined): ReturnType<typeof createPipelineRunner> {
+function buildRunner(
+  sourceFactory: SourceFactory | undefined,
+  progressContextFactory: ProgressContextFactory,
+): ReturnType<typeof createPipelineRunner> {
   const fileAnalyzer = createLlmFileAnalyzer({
     buildSystemPrompt: () => COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
     buildUserPrompt: buildFileAnalysisUserPrompt,
   });
-  const strategy = createFlatFolderStrategy({ fileAnalyzer });
+  const strategy = createFlatFolderStrategy({ fileAnalyzer, progressContextFactory });
   const runnerDeps: Parameters<typeof createPipelineRunner>[0] = { reposRootDir: reposRoot(), strategy };
   if (sourceFactory !== undefined) {
     runnerDeps.sourceFactory = sourceFactory;
@@ -37,14 +43,15 @@ function buildRunner(sourceFactory: SourceFactory | undefined): ReturnType<typeo
 }
 
 export function registerGithubWorkers(deps: RegisterGithubWorkersDeps = {}): void {
-  const runner = buildRunner(deps.sourceFactory);
+  const progressContextFactory = deps.progressContextFactory ?? nullProgressContextFactory;
+  const runner = buildRunner(deps.sourceFactory, progressContextFactory);
   registerWorker(JobType.GithubIndex, createGithubIngestHandler({ runner }));
   const pullFactory = deps.pullFactory;
-  registerWorker(JobType.GithubPull, (msg) => runPull(msg, pullFactory));
+  registerWorker(JobType.GithubPull, (msg) => runPull(msg, pullFactory, progressContextFactory));
 }
 
 export function registerLocalIngestWorker(): void {
-  const runner = buildRunner(undefined);
+  const runner = buildRunner(undefined, nullProgressContextFactory);
   registerWorker(JobType.LocalIngest, createLocalIngestHandler({ runner }));
 }
 
@@ -86,3 +93,12 @@ export {
   COMBINED_CODE_ANALYSIS_SYSTEM_PROMPT,
   buildFileAnalysisUserPrompt,
 } from "./strategies/flat-folder/prompts/file-analysis.ts";
+export type {
+  ProgressContext,
+  ProgressContextFactory,
+  ProgressPhase,
+  ProgressReporter,
+  ProgressReporterInput,
+  ProgressTotalMode,
+} from "./progress/types.ts";
+export { nullProgressContextFactory } from "./progress/NullProgressReporter.ts";

--- a/packages/ingest-github/src/index.ts
+++ b/packages/ingest-github/src/index.ts
@@ -35,7 +35,11 @@ function buildRunner(
     buildUserPrompt: buildFileAnalysisUserPrompt,
   });
   const strategy = createFlatFolderStrategy({ fileAnalyzer, progressContextFactory });
-  const runnerDeps: Parameters<typeof createPipelineRunner>[0] = { reposRootDir: reposRoot(), strategy };
+  const runnerDeps: Parameters<typeof createPipelineRunner>[0] = {
+    reposRootDir: reposRoot(),
+    strategy,
+    progressContextFactory,
+  };
   if (sourceFactory !== undefined) {
     runnerDeps.sourceFactory = sourceFactory;
   }

--- a/packages/ingest-github/src/pipeline/README.md
+++ b/packages/ingest-github/src/pipeline/README.md
@@ -62,7 +62,7 @@ llmCallContext`, which every LLM call site downstream consumes. State
   transitions (`CREATED → QUEUED → INGESTED → …`) are persisted to Mongo
   - Neo4j via `transitionState`, and `CancellationError` is re-thrown
     without flipping to FAILED.
-- `pull.ts` — `runPull(msg, pullFactory?)` orchestrates the pull job.
+- `pull.ts` — `runPull(msg, pullFactory?, progressContextFactory?)` orchestrates the pull job.
   Reads `repoUrl` and `branch` directly off `knowledge.info.*` (loaded via
   `@bb/mongo.getKnowledge`). The `KnowledgeSource` discriminator (`kind`) is
   still read off `knowledge.source` along with `commitId`/`commitHashes`, but
@@ -77,6 +77,13 @@ archiveSink?}` and `runPull` skips `syncRepository` + `materialiseEndpoints`
     `processBigFilesQueue`, `backfillMissingFields`, `backfillBigFiles`,
     `runSelectiveFolderSummary`, `summariseRepo`, `storePullAnalysis`.
     Mirrors `run.ts` for `llmCallContext` extraction from payload.
+    Mirrors the index-side strategy orchestrator for progress: builds one
+    `ProgressContext` per job from the optional `progressContextFactory`
+    (default `nullProgressContextFactory`), emits `phaseChanged` at
+    `file_analysis` / `folder_analysis` / `indexing` boundaries, threads
+    the context into every phase that takes a `progressContext?` field,
+    and finishes with `completed()` on success or `failed(message)` on a
+    non-`CancellationError` throw.
 - `pull-helpers.ts` — small pure helpers extracted from `pull.ts` to keep it
   under the 300-line cap: `persistPullStats` writes the per-commit row into
   `processing_stats`, `repoNameFromUrl` parses an owner/repo display name out

--- a/packages/ingest-github/src/pipeline/README.md
+++ b/packages/ingest-github/src/pipeline/README.md
@@ -43,7 +43,7 @@ true` (default). Consumed by `scan.ts` via the optional `skipDecider`
   unknown-extension gate uses per-job credentials. `readScannedFile`
   re-reads a file by absolute path for the big-file phase which streams
   content lazily.
-- `run.ts` — `createPipelineRunner({ reposRootDir, strategy, sourceFactory? })`
+- `run.ts` — `createPipelineRunner({ reposRootDir, strategy, sourceFactory?, progressContextFactory? })`
   builds an `IngestRunnerDeps`. GitHub payloads run: branch resolve,
   source-reader construction, strategy execute, commit persistence. Local
   payloads skip the clone. The source reader is chosen by the optional
@@ -61,7 +61,15 @@ true` (default). Consumed by `scan.ts` via the optional `skipDecider`
 llmCallContext`, which every LLM call site downstream consumes. State
   transitions (`CREATED → QUEUED → INGESTED → …`) are persisted to Mongo
   - Neo4j via `transitionState`, and `CancellationError` is re-thrown
-    without flipping to FAILED.
+    without flipping to FAILED. The optional `progressContextFactory`
+    is the runner's own `ProgressContext` source: `runGithub` emits
+    `phaseChanged("clone")` before `syncRepository` (or before the
+    `sourceFactory` call) and `phaseChanged("scan")` before invoking
+    `strategy.execute`, so SSE clients see liveness during the
+    network/disk-bound prelude. On a non-`CancellationError` throw the
+    runner emits `failed(message)` only when the strategy has not yet
+    started — once `strategy.execute` is reached, the strategy owns
+    terminal emission and the runner stays silent to avoid double-FAILED.
 - `pull.ts` — `runPull(msg, pullFactory?, progressContextFactory?)` orchestrates the pull job.
   Reads `repoUrl` and `branch` directly off `knowledge.info.*` (loaded via
   `@bb/mongo.getKnowledge`). The `KnowledgeSource` discriminator (`kind`) is

--- a/packages/ingest-github/src/pipeline/pull.ts
+++ b/packages/ingest-github/src/pipeline/pull.ts
@@ -14,6 +14,8 @@ import { computePullDiff, materialiseEndpoints } from "./pull-diff-resolver.ts";
 import { affectedFoldersFromDiff } from "./affected-folders.ts";
 import { createDiskSourceReader } from "./disk-source-reader.ts";
 import type { PullFactory, SourceReader, ArchiveSink } from "src/types/pipeline.ts";
+import type { ProgressContextFactory } from "src/progress/types.ts";
+import { nullProgressContextFactory } from "src/progress/NullProgressReporter.ts";
 import { analyseChangedFiles } from "src/strategies/flat-folder/analyse-changed.ts";
 import { processBigFilesQueue } from "src/strategies/flat-folder/phases/process-big-files.ts";
 import { backfillMissingFields } from "src/strategies/flat-folder/backfill/fields.ts";
@@ -54,7 +56,11 @@ function llmCallContextFromPayload(payload: {
   return Object.keys(ctx).length > 0 ? ctx : undefined;
 }
 
-export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: PullFactory): Promise<void> {
+export async function runPull(
+  msg: JobMessage<GithubPullPayload>,
+  pullFactory?: PullFactory,
+  progressContextFactory: ProgressContextFactory = nullProgressContextFactory,
+): Promise<void> {
   const { knowledgeId } = msg.payload;
   if (msg.payload.targetCommitHash !== undefined && !COMMIT_HASH_RE.test(msg.payload.targetCommitHash)) {
     throw new IngestError(
@@ -88,6 +94,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
   clearCancellation(knowledgeId);
   const startedAt = Date.now();
   await transitionState(knowledgeId, KnowledgeState.Processing);
+  const progressContext = progressContextFactory(knowledgeId);
 
   try {
     throwIfCancelled(knowledgeId);
@@ -169,6 +176,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
 
     const llmCallContext = llmCallContextFromPayload(msg.payload);
 
+    progressContext.phaseChanged("file_analysis");
     logger.info(`pull: phase per-file dispatcher for ${knowledgeId} starting`);
     throwIfCancelled(knowledgeId);
     const analyseChangedInput: Parameters<typeof analyseChangedFiles>[0] = {
@@ -177,6 +185,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
       metaPaths,
       analyzer: fileAnalyzer,
       diff,
+      progressContext,
     };
     if (llmCallContext !== undefined) {
       analyseChangedInput.llmCallContext = llmCallContext;
@@ -188,7 +197,12 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
 
     logger.info(`pull: phase process big files starting`);
     throwIfCancelled(knowledgeId);
-    const processBigFilesInput: Parameters<typeof processBigFilesQueue>[0] = { knowledgeId, source, metaPaths };
+    const processBigFilesInput: Parameters<typeof processBigFilesQueue>[0] = {
+      knowledgeId,
+      source,
+      metaPaths,
+      progressContext,
+    };
     if (llmCallContext !== undefined) {
       processBigFilesInput.llmCallContext = llmCallContext;
     }
@@ -196,16 +210,22 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
 
     logger.info(`pull: phase backfill fields starting`);
     throwIfCancelled(knowledgeId);
-    await backfillMissingFields(metaPaths, llmCallContext);
+    await backfillMissingFields(metaPaths, llmCallContext, progressContext);
 
     logger.info(`pull: phase backfill big-files starting`);
     throwIfCancelled(knowledgeId);
-    const backfillBigFilesInput: Parameters<typeof backfillBigFiles>[0] = { knowledgeId, source, metaPaths };
+    const backfillBigFilesInput: Parameters<typeof backfillBigFiles>[0] = {
+      knowledgeId,
+      source,
+      metaPaths,
+      progressContext,
+    };
     if (llmCallContext !== undefined) {
       backfillBigFilesInput.llmCallContext = llmCallContext;
     }
     await backfillBigFiles(backfillBigFilesInput);
 
+    progressContext.phaseChanged("folder_analysis");
     logger.info(`pull: phase selective folder summary (${affectedFolders.size} folders) starting`);
     throwIfCancelled(knowledgeId);
     const selectiveInput: Parameters<typeof runSelectiveFolderSummary>[0] = {
@@ -218,6 +238,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
     }
     await runSelectiveFolderSummary(selectiveInput);
 
+    progressContext.phaseChanged("indexing");
     logger.info(`pull: phase repo summary starting`);
     throwIfCancelled(knowledgeId);
     const orgId = resolveOrgId({ ...(knowledge.source.kind === "github" ? {} : {}) });
@@ -248,6 +269,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
     });
     await setKnowledgeCommit(knowledgeId, targetCommit);
     await transitionState(knowledgeId, KnowledgeState.Processed);
+    progressContext.completed("github_pull complete");
     logger.info(
       `pull: ${knowledgeId} ${currentCommit.slice(0, 12)} -> ${targetCommit.slice(0, 12)} done (filesUpserted=${stored.filesUpserted} filesDeleted=${stored.filesDeleted} foldersUpserted=${stored.foldersUpserted})`,
     );
@@ -258,6 +280,7 @@ export async function runPull(msg: JobMessage<GithubPullPayload>, pullFactory?: 
       throw cause;
     }
     await transitionState(knowledgeId, KnowledgeState.Failed).catch(() => undefined);
+    progressContext.failed(describe(cause));
     throw new IngestError(knowledgeId, `github_pull failed: ${describe(cause)}`, cause);
   }
 }

--- a/packages/ingest-github/src/pipeline/run.ts
+++ b/packages/ingest-github/src/pipeline/run.ts
@@ -8,6 +8,8 @@ import { logger } from "@bb/logger";
 import type { IngestRunnerDeps, IngestRunnerInput } from "src/types/ingest-runner.ts";
 import type { IngestStrategy } from "src/types/strategy.ts";
 import type { ArchiveSink, PipelineSummary, SourceFactory, SourceReader } from "src/types/pipeline.ts";
+import type { ProgressContextFactory } from "src/progress/types.ts";
+import { nullProgressContextFactory } from "src/progress/NullProgressReporter.ts";
 import { ensureMetaDirs, ensureReposRoot, metaPathsFor, repoCloneDir } from "./paths.ts";
 import { readHeadCommitHash, syncRepository } from "./source.ts";
 import { resolveBranch } from "./branch.ts";
@@ -49,16 +51,23 @@ export interface CreatePipelineRunnerDeps {
    * supplies one.
    */
   sourceFactory?: SourceFactory;
+  /**
+   * Optional progress context factory. When provided, the runner emits
+   * pre-strategy phase changes (`clone`, `scan`) so SSE clients see liveness
+   * during the network/disk-bound prelude. Defaults to a no-op.
+   */
+  progressContextFactory?: ProgressContextFactory;
 }
 
 export function createPipelineRunner(deps: CreatePipelineRunnerDeps): IngestRunnerDeps {
+  const progressContextFactory = deps.progressContextFactory ?? nullProgressContextFactory;
   return {
     reposRootDir: deps.reposRootDir,
     strategy: deps.strategy,
     run: async (input: IngestRunnerInput): Promise<PipelineSummary> => {
       const payload = input.payload;
       if (isGithubPayload(payload)) {
-        return await runGithub(deps.strategy, payload, deps.sourceFactory);
+        return await runGithub(deps.strategy, payload, deps.sourceFactory, progressContextFactory);
       }
       return await runLocal(deps.strategy, payload);
     },
@@ -69,11 +78,14 @@ async function runGithub(
   strategy: IngestStrategy,
   payload: GithubIndexPayload,
   sourceFactory: SourceFactory | undefined,
+  progressContextFactory: ProgressContextFactory,
 ): Promise<PipelineSummary> {
   const { knowledgeId } = payload;
   clearCancellation(knowledgeId);
   const startedAt = Date.now();
   await transitionState(knowledgeId, KnowledgeState.Processing);
+  const progressContext = progressContextFactory(knowledgeId);
+  let strategyStarted = false;
   try {
     throwIfCancelled(knowledgeId);
     const branch = resolveBranch(knowledgeId, payload);
@@ -82,6 +94,7 @@ async function runGithub(
     let archiveSink: ArchiveSink | undefined;
     let commitHash: string;
 
+    progressContext.phaseChanged("clone");
     if (sourceFactory !== undefined) {
       const factoryResult = await sourceFactory({ knowledgeId, payload, branch });
       source = factoryResult.source;
@@ -107,6 +120,7 @@ async function runGithub(
       source = createDiskSourceReader({ repoDir, commitHash });
     }
 
+    progressContext.phaseChanged("scan");
     const metaPaths = metaPathsFor(knowledgeId);
     await ensureMetaDirs(metaPaths);
 
@@ -129,6 +143,7 @@ async function runGithub(
     if (archiveSink !== undefined) {
       strategyInput.archiveSink = archiveSink;
     }
+    strategyStarted = true;
     const result = await strategy.execute(strategyInput);
 
     await persistStats({
@@ -161,6 +176,9 @@ async function runGithub(
       throw cause;
     }
     await transitionState(knowledgeId, KnowledgeState.Failed).catch(() => undefined);
+    if (!strategyStarted) {
+      progressContext.failed(describe(cause));
+    }
     throw new IngestError(knowledgeId, `github_index pipeline failed: ${describe(cause)}`, cause);
   }
 }

--- a/packages/ingest-github/src/progress/NullProgressReporter.ts
+++ b/packages/ingest-github/src/progress/NullProgressReporter.ts
@@ -1,0 +1,45 @@
+import type {
+  ProgressContext,
+  ProgressContextFactory,
+  ProgressPhase,
+  ProgressReporter,
+  ProgressReporterInput,
+} from "src/progress/types.ts";
+
+class NullProgressReporter implements ProgressReporter {
+  async start(): Promise<void> {
+    /* no-op */
+  }
+  increment(_delta?: number, _meta?: { fileName?: string }): void {
+    /* no-op */
+  }
+  incrementSeen(_delta?: number): void {
+    /* no-op */
+  }
+  setTotal(_total: number): void {
+    /* no-op */
+  }
+  stop(): void {
+    /* no-op */
+  }
+}
+
+class NullProgressContext implements ProgressContext {
+  reporter(_input: ProgressReporterInput): ProgressReporter {
+    return new NullProgressReporter();
+  }
+  phaseChanged(_phase: ProgressPhase): void {
+    /* no-op */
+  }
+  completed(_message?: string): void {
+    /* no-op */
+  }
+  failed(_error: string, _phase?: ProgressPhase): void {
+    /* no-op */
+  }
+}
+
+const SINGLETON: ProgressContext = new NullProgressContext();
+
+/** Default factory used when no host binary supplies one. */
+export const nullProgressContextFactory: ProgressContextFactory = (_knowledgeId: string) => SINGLETON;

--- a/packages/ingest-github/src/progress/README.md
+++ b/packages/ingest-github/src/progress/README.md
@@ -1,0 +1,35 @@
+# `ingest-github / progress`
+
+**Tier:** Domain extension port
+
+## Responsibility
+
+Defines the host-binary extension port for observing ingestion-phase progress without coupling `@bb/ingest-github` to any transport.
+
+The strategy emits two kinds of signals through this port:
+
+- **Intra-phase ticks** via `ProgressReporter` — one reporter per phase or sub-phase of one job, driven by the strategy as it makes progress.
+- **Phase boundaries and terminal state** via `ProgressContext.phaseChanged / completed / failed`.
+
+A host binary supplies a `ProgressContextFactory(knowledgeId)`. `@bb/server` does not — it falls back to `nullProgressContextFactory`, which discards every signal.
+
+## Public API
+
+- `ProgressPhase` — `"file_analysis" | "folder_analysis" | "indexing"`
+- `ProgressTotalMode` — `{ kind: "fixed"; total }` or `{ kind: "growing"; initialTotal? }`
+- `ProgressReporterInput` — phase + sub-phase + total mode + optional restart-seed hook
+- `ProgressReporter` — `start / increment / incrementSeen / setTotal / stop`
+- `ProgressContext` — bundles `reporter()` with boundary-event publishers
+- `ProgressContextFactory` — `(knowledgeId) => ProgressContext`
+- `nullProgressContextFactory` — no-op fallback used when the host does not supply one
+
+## Invariants
+
+- Pure types and a no-op default. No transport. No outbound calls.
+- Tracker decisions (sampling cadence, persistence, fanout) belong to the host implementation.
+- The strategy must call `reporter.stop()` in a `finally` so the host can emit a final tick deterministically.
+- Reporters returned for the same `(knowledgeId, phase, subPhase)` are not reused across invocations — each `reporter()` call returns a fresh instance.
+
+## External dependencies
+
+None.

--- a/packages/ingest-github/src/progress/README.md
+++ b/packages/ingest-github/src/progress/README.md
@@ -15,7 +15,7 @@ A host binary supplies a `ProgressContextFactory(knowledgeId)`. `@bb/server` doe
 
 ## Public API
 
-- `ProgressPhase` — `"file_analysis" | "folder_analysis" | "indexing"`
+- `ProgressPhase` — `"clone" | "scan" | "file_analysis" | "folder_analysis" | "indexing"`. `clone` and `scan` are emitted by `runGithub` (the runner) before the strategy starts, so SSE clients see liveness during the network/disk-bound prelude. `file_analysis`, `folder_analysis`, and `indexing` are emitted by the strategy.
 - `ProgressTotalMode` — `{ kind: "fixed"; total }` or `{ kind: "growing"; initialTotal? }`
 - `ProgressReporterInput` — phase + sub-phase + total mode + optional restart-seed hook
 - `ProgressReporter` — `start / increment / incrementSeen / setTotal / stop`

--- a/packages/ingest-github/src/progress/types.ts
+++ b/packages/ingest-github/src/progress/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Progress-reporting extension port.
+ *
+ * `@bb/ingest-github` exposes this interface so a host binary can observe
+ * phase progress without the strategy importing the host's transport. The
+ * default is a no-op (`NullProgressContext`) — consistent with the
+ * no-outbound-calls posture.
+ */
+
+export type ProgressPhase = "file_analysis" | "folder_analysis" | "indexing";
+
+export type ProgressTotalMode =
+  | { kind: "fixed"; total: number }
+  | { kind: "growing"; initialTotal?: number };
+
+export interface ProgressReporterInput {
+  readonly phase: ProgressPhase;
+  readonly subPhase?: string;
+  readonly total: ProgressTotalMode;
+  readonly resolveInitialProcessed?: () => Promise<number> | number;
+}
+
+/**
+ * Per-phase progress sink. One instance per phase or sub-phase of a job.
+ * The host implementation decides whether emissions are timer-sampled,
+ * push-per-call, persisted, or discarded.
+ */
+export interface ProgressReporter {
+  start(): Promise<void>;
+  increment(delta?: number, meta?: { fileName?: string }): void;
+  /** Grow the denominator when the work set is a streaming iterator. */
+  incrementSeen(delta?: number): void;
+  setTotal(total: number): void;
+  stop(): void;
+}
+
+/**
+ * Bundle of progress facilities scoped to a single ingestion job. Returned
+ * by `ProgressContextFactory(knowledgeId)`.
+ */
+export interface ProgressContext {
+  reporter(input: ProgressReporterInput): ProgressReporter;
+  phaseChanged(phase: ProgressPhase): void;
+  completed(message?: string): void;
+  failed(error: string, phase?: ProgressPhase): void;
+}
+
+export type ProgressContextFactory = (knowledgeId: string) => ProgressContext;

--- a/packages/ingest-github/src/progress/types.ts
+++ b/packages/ingest-github/src/progress/types.ts
@@ -9,9 +9,7 @@
 
 export type ProgressPhase = "file_analysis" | "folder_analysis" | "indexing";
 
-export type ProgressTotalMode =
-  | { kind: "fixed"; total: number }
-  | { kind: "growing"; initialTotal?: number };
+export type ProgressTotalMode = { kind: "fixed"; total: number } | { kind: "growing"; initialTotal?: number };
 
 export interface ProgressReporterInput {
   readonly phase: ProgressPhase;

--- a/packages/ingest-github/src/progress/types.ts
+++ b/packages/ingest-github/src/progress/types.ts
@@ -7,7 +7,7 @@
  * no-outbound-calls posture.
  */
 
-export type ProgressPhase = "file_analysis" | "folder_analysis" | "indexing";
+export type ProgressPhase = "clone" | "scan" | "file_analysis" | "folder_analysis" | "indexing";
 
 export type ProgressTotalMode = { kind: "fixed"; total: number } | { kind: "growing"; initialTotal?: number };
 

--- a/packages/ingest-github/src/strategies/flat-folder/README.md
+++ b/packages/ingest-github/src/strategies/flat-folder/README.md
@@ -30,13 +30,43 @@ sub-phase boundary.
    flat-folder indexes, upsert `:Repo`, then every `:Folder`, then every
    `:File` with the extended analysis + Folder→File `CONTAINS` edge.
 
+## Progress events
+
+The strategy emits progress through the `ProgressContext` port defined in
+`src/progress/`. `createFlatFolderStrategy(deps)` accepts an optional
+`progressContextFactory`; absent → `nullProgressContextFactory`
+(no-op, OSS default).
+
+- **Boundary events** are emitted by `index.ts`:
+  - `phaseChanged("file_analysis")` before phase 1
+  - `phaseChanged("folder_analysis")` before phase 5
+  - `phaseChanged("indexing")` before phase 6 (which feeds phase 7)
+  - `completed()` after phase 7 returns
+  - `failed(message)` from a `try/catch` wrapping the whole `execute`
+- **Intra-phase ticks** are emitted by each phase via per-phase reporters
+  created from `progressContext.reporter(...)`. Sub-phase labels:
+  - phase 1 → no sub-phase (the main file-analysis loop)
+  - phase 2 → `big_files_queue`; inner `processBigFile` adds
+    `big_file:<relativePath>` for chunk pulses
+  - phase 3 → `backfill`; phase 4 → `backfill:big_files`
+- **Total mode**: phase 1, phase 3, and any other streaming-iterator loop
+  use `total: { kind: "growing" }` (denominator grows as `source.scan`
+  yields). Phases 2 and 4, plus the big-file chunk pool, know their size
+  up front and use `total: { kind: "fixed", total: N }`.
+- The cancellation path in `execute` lets `CancellationError` propagate
+  past the orchestrator; `failed()` only fires for non-cancellation
+  errors.
+
 ## Files
 
 - `index.ts` — `createFlatFolderStrategy(deps)` orchestrates the 7 phases.
+  Accepts `{ fileAnalyzer, progressContextFactory? }`. Constructs one
+  `ProgressContext` per job and threads it into every phase that takes a
+  `progressContext?` field.
 - `types.ts` — `AnalyzedFileEntry`, `FolderSummary`, `RepoSummary`,
   `RepoSummaryEnvelope`, `FlatFolderResult`.
 - `analyse-file.ts` — `analyseScannedFile(analyzer, file, llmCallContext?)` + `buildOversizedStub`.
-- `analyse-changed.ts` — `analyseChangedFiles({knowledgeId, source, metaPaths, analyzer, diff, llmCallContext?, archiveSink?})`. Pull-time per-file dispatcher. Reads changed file content through `input.source` (a `SourceReader`) so it works with both the disk-backed reader (OSS default) and any HTTP-backed alternative supplied via the `pullFactory` hook. Mirrors `classifyAndAnalyseSmall`'s small-file path: filter → fetch → size cap → binary detect → line count → analyse → save + archive push. Does NOT invoke the skip-decision LLM gate.
+- `analyse-changed.ts` — `analyseChangedFiles({knowledgeId, source, metaPaths, analyzer, diff, llmCallContext?, archiveSink?, progressContext?})`. Pull-time per-file dispatcher. Reads changed file content through `input.source` (a `SourceReader`) so it works with both the disk-backed reader (OSS default) and any HTTP-backed alternative supplied via the `pullFactory` hook. Mirrors `classifyAndAnalyseSmall`'s small-file path: filter → fetch → size cap → binary detect → line count → analyse → save + archive push. Does NOT invoke the skip-decision LLM gate. When `progressContext` is present it creates a fixed-total reporter (`subPhase: "pull"`, `total = dedupedPaths.length`) and increments per-path so the pull SSE stream stays live.
 - `folder-path.ts` — `directFolderOf`, `affectedFolderPaths`.
 - `folder-summary.ts` — group + summarise + persist + iterate folder summaries.
 - `repo-summary.ts` — single-shot or batched repo summary with envelope writer.

--- a/packages/ingest-github/src/strategies/flat-folder/README.md
+++ b/packages/ingest-github/src/strategies/flat-folder/README.md
@@ -37,8 +37,11 @@ The strategy emits progress through the `ProgressContext` port defined in
 `progressContextFactory`; absent → `nullProgressContextFactory`
 (no-op, OSS default).
 
-- **Boundary events** are emitted by `index.ts`:
-  - `phaseChanged("file_analysis")` before phase 1
+- **Boundary events** are split between the runner and the strategy:
+  - `phaseChanged("clone")` and `phaseChanged("scan")` are emitted by
+    `pipeline/run.ts` (the runner) before `strategy.execute` is called,
+    so the SSE stream stays alive during the network/disk-bound prelude.
+  - `phaseChanged("file_analysis")` is emitted by `index.ts` before phase 1
   - `phaseChanged("folder_analysis")` before phase 5
   - `phaseChanged("indexing")` before phase 6 (which feeds phase 7)
   - `completed()` after phase 7 returns
@@ -49,6 +52,9 @@ The strategy emits progress through the `ProgressContext` port defined in
   - phase 2 → `big_files_queue`; inner `processBigFile` adds
     `big_file:<relativePath>` for chunk pulses
   - phase 3 → `backfill`; phase 4 → `backfill:big_files`
+  - phase 5 → no sub-phase, fixed total = directly-grouped folder count
+  - phase 7 → `folders` then `files`, both `growing` (drained from
+    on-disk async generators)
 - **Total mode**: phase 1, phase 3, and any other streaming-iterator loop
   use `total: { kind: "growing" }` (denominator grows as `source.scan`
   yields). Phases 2 and 4, plus the big-file chunk pool, know their size

--- a/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/analyse-changed.ts
@@ -6,6 +6,7 @@ import { getConfigValue } from "@bb/config";
 import type { ArchiveSink, FileAnalyzer, ScannedFile, SourceReader } from "src/types/pipeline.ts";
 import type { MetaPaths } from "src/types/meta-paths.ts";
 import type { BigFileEntry } from "src/types/big-file.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { looksBinary, passesPathFilters } from "src/pipeline/filters.ts";
 import { withConcurrency } from "src/pipeline/concurrency.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
@@ -23,13 +24,7 @@ export interface AnalyseChangedInput {
   llmCallContext?: AskLlmOptions;
   /** Optional non-fatal archive sink. When set, analysed content is pushed after `saveCondensed`. */
   archiveSink?: ArchiveSink;
-  /**
-   * Invoked once per consumed path (analysed, stubbed, queued-as-big-file,
-   * filtered, or failed). Lets the caller drive a `processedFiles` counter
-   * for the progress bar without coupling this strategy to mongo. Best
-   * effort — errors from the callback are swallowed.
-   */
-  onFileProcessed?: () => Promise<void> | void;
+  progressContext?: ProgressContext;
 }
 
 export interface AnalyseChangedResult {
@@ -85,113 +80,133 @@ export async function analyseChangedFiles(input: AnalyseChangedInput): Promise<A
 
   const pending: Promise<void>[] = [];
 
-  for (const relativePath of dedupedPaths) {
-    throwIfCancelled(input.knowledgeId);
-    const filename = path.basename(relativePath);
-    const ext = path.extname(filename).toLowerCase();
-    if (!passesPathFilters(filename, ext)) {
-      skipped += 1;
-      continue;
-    }
+  const reporter = input.progressContext?.reporter({
+    phase: "file_analysis",
+    subPhase: "pull",
+    total: { kind: "fixed", total: dedupedPaths.length },
+  });
+  await reporter?.start();
 
-    let content: string;
-    try {
-      content = await input.source.readFile(relativePath);
-    } catch (cause: unknown) {
-      failed += 1;
-      logger.warn(`pull-analyse: read failed for ${relativePath}: ${describe(cause)}`);
-      continue;
-    }
-    if (content.length === 0) {
-      skipped += 1;
-      continue;
-    }
-    const sizeBytes = Buffer.byteLength(content, "utf8");
+  try {
+    for (const relativePath of dedupedPaths) {
+      throwIfCancelled(input.knowledgeId);
+      const filename = path.basename(relativePath);
+      const ext = path.extname(filename).toLowerCase();
+      if (!passesPathFilters(filename, ext)) {
+        skipped += 1;
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
+      }
 
-    if (sizeBytes > absoluteCap) {
-      bigFileBuffer.push({
-        relativePath,
-        sizeBytes,
-        tokenCount: 0,
-        reason: "too-large",
-      });
+      let content: string;
       try {
-        await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
-        oversizedStubs += 1;
+        content = await input.source.readFile(relativePath);
       } catch (cause: unknown) {
         failed += 1;
-        logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
+        logger.warn(`pull-analyse: read failed for ${relativePath}: ${describe(cause)}`);
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
       }
-      continue;
-    }
-
-    if (looksBinary(Buffer.from(content, "utf8"))) {
-      skipped += 1;
-      continue;
-    }
-    if (countLines(content) > bigFileLineThreshold) {
-      bigFileBuffer.push({
-        relativePath,
-        sizeBytes,
-        tokenCount: 0,
-        reason: "too-large",
-      });
-      try {
-        await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
-        oversizedStubs += 1;
-      } catch (cause: unknown) {
-        failed += 1;
-        logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
+      if (content.length === 0) {
+        skipped += 1;
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
       }
-      continue;
-    }
+      const sizeBytes = Buffer.byteLength(content, "utf8");
 
-    const tokenCount = tokenLen(content);
-    if (tokenCount > contextWindowLimit) {
-      bigFileBuffer.push({
-        relativePath,
-        sizeBytes,
-        tokenCount,
-        reason: "context-window-exceeded",
-      });
-      continue;
-    }
-
-    const scanned: ScannedFile = {
-      kind: "file",
-      relativePath,
-      absolutePath: relativePath,
-      sizeBytes,
-      content,
-    };
-    const fileContent = content;
-    const filePath = relativePath;
-    pending.push(
-      limit(async () => {
+      if (sizeBytes > absoluteCap) {
+        bigFileBuffer.push({
+          relativePath,
+          sizeBytes,
+          tokenCount: 0,
+          reason: "too-large",
+        });
         try {
-          throwIfCancelled(input.knowledgeId);
-          const condensed = await analyseScannedFile(input.analyzer, scanned, input.llmCallContext);
-          await saveCondensed(input.metaPaths, condensed);
-          if (input.archiveSink !== undefined) {
-            await input.archiveSink.push({
-              knowledgeId: input.knowledgeId,
-              relativePath: filePath,
-              content: fileContent,
-            });
-          }
-          smallFilesAnalysed += 1;
+          await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
+          oversizedStubs += 1;
         } catch (cause: unknown) {
-          if (cause instanceof CancellationError) {
-            throw cause;
-          }
           failed += 1;
-          logger.warn(`pull-analyse: analyse failed for ${relativePath}: ${describe(cause)}`);
+          logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
         }
-      }),
-    );
-  }
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
+      }
 
-  await Promise.all(pending);
+      if (looksBinary(Buffer.from(content, "utf8"))) {
+        skipped += 1;
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
+      }
+      if (countLines(content) > bigFileLineThreshold) {
+        bigFileBuffer.push({
+          relativePath,
+          sizeBytes,
+          tokenCount: 0,
+          reason: "too-large",
+        });
+        try {
+          await saveCondensed(input.metaPaths, buildOversizedStub(relativePath, sizeBytes));
+          oversizedStubs += 1;
+        } catch (cause: unknown) {
+          failed += 1;
+          logger.warn(`pull-analyse: oversized stub write failed for ${relativePath}: ${describe(cause)}`);
+        }
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
+      }
+
+      const tokenCount = tokenLen(content);
+      if (tokenCount > contextWindowLimit) {
+        bigFileBuffer.push({
+          relativePath,
+          sizeBytes,
+          tokenCount,
+          reason: "context-window-exceeded",
+        });
+        // Big-file path runs in its own phase; this entry leaves the small-loop accounting.
+        reporter?.increment(1, { fileName: relativePath });
+        continue;
+      }
+
+      const scanned: ScannedFile = {
+        kind: "file",
+        relativePath,
+        absolutePath: relativePath,
+        sizeBytes,
+        content,
+      };
+      const fileContent = content;
+      const filePath = relativePath;
+      pending.push(
+        limit(async () => {
+          try {
+            throwIfCancelled(input.knowledgeId);
+            const condensed = await analyseScannedFile(input.analyzer, scanned, input.llmCallContext);
+            await saveCondensed(input.metaPaths, condensed);
+            if (input.archiveSink !== undefined) {
+              await input.archiveSink.push({
+                knowledgeId: input.knowledgeId,
+                relativePath: filePath,
+                content: fileContent,
+              });
+            }
+            smallFilesAnalysed += 1;
+          } catch (cause: unknown) {
+            if (cause instanceof CancellationError) {
+              throw cause;
+            }
+            failed += 1;
+            logger.warn(`pull-analyse: analyse failed for ${relativePath}: ${describe(cause)}`);
+          }
+          reporter?.increment(1, { fileName: filePath });
+        }),
+      );
+    }
+
+    await Promise.all(pending);
+  } finally {
+    reporter?.stop();
+  }
 
   if (bigFileBuffer.length > 0) {
     const existing = await readBigFiles(input.metaPaths);

--- a/packages/ingest-github/src/strategies/flat-folder/backfill/README.md
+++ b/packages/ingest-github/src/strategies/flat-folder/backfill/README.md
@@ -7,27 +7,33 @@ Both are idempotent and skip entries that already look complete.
 
 ## Files
 
-- `fields.ts` — Phase 3. `backfillMissingFields(metaPaths)` iterates every
-  condensed entry via `iterateCondensed`, computes which extended-analysis
-  fields are missing (`keywords`, `ontologyConcepts`, `businessEntities`,
-  `systemCapabilities`, `sideEffects`, `configDependencies`,
-  `dataFlowDirection`, `integrationSurface`, `contractsProvided`,
-  `contractsConsumed`, `sectionMap`), and asks one LLM call per file to
-  fill only the missing slots. The response is validated and normalised
-  (`pickStringArray`, `pickSections`) before being written back via
-  `saveCondensed`. Entries with nothing missing are skipped without an
-  LLM call.
+- `fields.ts` — Phase 3. `backfillMissingFields(metaPaths, llmCallContext?, progressContext?)`
+  iterates every condensed entry via `iterateCondensed`, computes which
+  extended-analysis fields are missing (`keywords`, `ontologyConcepts`,
+  `businessEntities`, `systemCapabilities`, `sideEffects`,
+  `configDependencies`, `dataFlowDirection`, `integrationSurface`,
+  `contractsProvided`, `contractsConsumed`, `sectionMap`), and asks one
+  LLM call per file to fill only the missing slots. The response is
+  validated and normalised (`pickStringArray`, `pickSections`) before
+  being written back via `saveCondensed`. Entries with nothing missing
+  are skipped without an LLM call. When `progressContext` is present
+  this phase opens a growing-total reporter (`subPhase: "backfill"`)
+  because `iterateCondensed`'s size is not known up front.
 - `big-files.ts` — Phase 4. `backfillBigFiles({knowledgeId, repoDir,
-metaPaths})` re-reads `bigFiles.json`, skips `reason === "too-large"`,
-  and for each non-complete entry (per `inspect`) re-runs `processBigFile`
-  against the file on disk so the condensed JSON is rebuilt from cached
-  chunks where possible.
+metaPaths, llmCallContext?, progressContext?})` re-reads
+  `bigFiles.json`, skips `reason === "too-large"`, and for each
+  non-complete entry (per `inspect`) re-runs `processBigFile` against
+  the file on disk so the condensed JSON is rebuilt from cached chunks
+  where possible. When `progressContext` is present this phase opens a
+  fixed-total reporter (`subPhase: "backfill:big_files"`, sized by
+  `bigFiles.json`) and forwards itself into `processBigFile` so per-file
+  chunk pulses also surface.
 
 ## Public interfaces
 
-- `backfillMissingFields(metaPaths, llmCallContext?): Promise<{ updated, failed }>`
+- `backfillMissingFields(metaPaths, llmCallContext?, progressContext?): Promise<{ updated, failed }>`
 - `backfillBigFiles(input: BackfillBigFilesInput): Promise<BackfillBigFilesResult>`
-  — `BackfillBigFilesInput` carries an optional `llmCallContext?: AskLlmOptions` that the inner `processBigFile` call uses to forward per-job LLM credentials.
+  — `BackfillBigFilesInput` carries an optional `llmCallContext?: AskLlmOptions` that the inner `processBigFile` call uses to forward per-job LLM credentials, and an optional `progressContext?: ProgressContext` for the per-phase reporter described above.
 
 Both return phase-summary counters consumed by `createFlatFolderStrategy`
 to roll up into the strategy result.

--- a/packages/ingest-github/src/strategies/flat-folder/backfill/big-files.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/backfill/big-files.ts
@@ -2,6 +2,7 @@ import { logger } from "@bb/logger";
 import type { AskLlmOptions } from "@bb/llm";
 import type { MetaPaths } from "src/types/meta-paths.ts";
 import type { SourceReader } from "src/types/pipeline.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { readBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
 import { inspect } from "src/strategies/flat-folder/big-file/cache.ts";
 import { processBigFile } from "src/strategies/flat-folder/big-file/index.ts";
@@ -11,6 +12,7 @@ export interface BackfillBigFilesInput {
   source: SourceReader;
   metaPaths: MetaPaths;
   llmCallContext?: AskLlmOptions;
+  progressContext?: ProgressContext;
 }
 
 export interface BackfillBigFilesResult {
@@ -22,36 +24,51 @@ export async function backfillBigFiles(input: BackfillBigFilesInput): Promise<Ba
   const entries = await readBigFiles(input.metaPaths);
   let reCondensed = 0;
   let failed = 0;
-  for (const entry of entries) {
-    if (entry.reason === "too-large") {
-      continue;
-    }
-    const status = await inspect(input.metaPaths, entry.relativePath);
-    if (status === "complete") {
-      continue;
-    }
-    try {
-      const content = await input.source.readFile(entry.relativePath);
-      if (content.length === 0) {
-        failed += 1;
-        logger.warn(`phase4: empty content for ${entry.relativePath}; skipping`);
+  const reporter = input.progressContext?.reporter({
+    phase: "file_analysis",
+    subPhase: "backfill:big_files",
+    total: { kind: "fixed", total: entries.length },
+  });
+  await reporter?.start();
+  try {
+    for (const entry of entries) {
+      if (entry.reason === "too-large") {
+        reporter?.increment(1, { fileName: entry.relativePath });
         continue;
       }
-      await processBigFile({
-        knowledgeId: input.knowledgeId,
-        metaPaths: input.metaPaths,
-        relativePath: entry.relativePath,
-        content,
-        sizeBytes: entry.sizeBytes,
-        ...(input.llmCallContext !== undefined ? { llmCallContext: input.llmCallContext } : {}),
-      });
-      reCondensed += 1;
-    } catch (cause: unknown) {
-      failed += 1;
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      logger.warn(`phase4: re-condense failed for ${entry.relativePath}: ${msg}`);
+      const status = await inspect(input.metaPaths, entry.relativePath);
+      if (status === "complete") {
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
+      }
+      try {
+        const content = await input.source.readFile(entry.relativePath);
+        if (content.length === 0) {
+          failed += 1;
+          logger.warn(`phase4: empty content for ${entry.relativePath}; skipping`);
+          reporter?.increment(1, { fileName: entry.relativePath });
+          continue;
+        }
+        await processBigFile({
+          knowledgeId: input.knowledgeId,
+          metaPaths: input.metaPaths,
+          relativePath: entry.relativePath,
+          content,
+          sizeBytes: entry.sizeBytes,
+          ...(input.llmCallContext !== undefined ? { llmCallContext: input.llmCallContext } : {}),
+          ...(input.progressContext !== undefined ? { progressContext: input.progressContext } : {}),
+        });
+        reCondensed += 1;
+      } catch (cause: unknown) {
+        failed += 1;
+        const msg = cause instanceof Error ? cause.message : String(cause);
+        logger.warn(`phase4: re-condense failed for ${entry.relativePath}: ${msg}`);
+      }
+      reporter?.increment(1, { fileName: entry.relativePath });
     }
+    logger.info(`phase4 done: reCondensed=${reCondensed} failed=${failed}`);
+    return { reCondensed, failed };
+  } finally {
+    reporter?.stop();
   }
-  logger.info(`phase4 done: reCondensed=${reCondensed} failed=${failed}`);
-  return { reCondensed, failed };
 }

--- a/packages/ingest-github/src/strategies/flat-folder/backfill/fields.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/backfill/fields.ts
@@ -2,6 +2,7 @@ import { askJsonLLM, type AskLlmOptions } from "@bb/llm";
 import { logger } from "@bb/logger";
 import type { FileAnalysis, FileAnalysisSection } from "@bb/mongo";
 import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { iterateCondensed } from "src/strategies/flat-folder/big-file/storage.ts";
 import { saveCondensed } from "src/strategies/flat-folder/big-file/storage.ts";
 import { BACKFILL_SYSTEM_PROMPT, buildBackfillUserPrompt } from "src/strategies/flat-folder/prompts/backfill.ts";
@@ -43,32 +44,47 @@ interface NeededFlags {
 export async function backfillMissingFields(
   metaPaths: MetaPaths,
   llmCallContext?: AskLlmOptions,
+  progressContext?: ProgressContext,
 ): Promise<{ updated: number; failed: number }> {
   let updated = 0;
   let failed = 0;
-  for await (const entry of iterateCondensed(metaPaths)) {
-    const a = entry.analysis;
-    const needed = computeNeeded(a);
-    if (!hasAnyMissing(needed)) {
-      continue;
-    }
-    const userPrompt = buildBackfillUserPrompt(entry.relativePath, entry.analysis);
-    try {
-      const response = await askJsonLLM<BackfillJson>(BACKFILL_SYSTEM_PROMPT, userPrompt, llmCallContext ?? {});
-      const result = response.result;
-      if (result === null) {
+  const reporter = progressContext?.reporter({
+    phase: "file_analysis",
+    subPhase: "backfill",
+    total: { kind: "growing" },
+  });
+  await reporter?.start();
+  try {
+    for await (const entry of iterateCondensed(metaPaths)) {
+      reporter?.incrementSeen();
+      const a = entry.analysis;
+      const needed = computeNeeded(a);
+      if (!hasAnyMissing(needed)) {
+        reporter?.increment(1, { fileName: entry.relativePath });
         continue;
       }
-      applyBackfill(a, result, needed);
-      await saveCondensed(metaPaths, entry);
-      updated += 1;
-    } catch (cause: unknown) {
-      failed += 1;
-      logger.warn(`phase3: backfill failed for ${entry.relativePath}: ${describe(cause)}`);
+      const userPrompt = buildBackfillUserPrompt(entry.relativePath, entry.analysis);
+      try {
+        const response = await askJsonLLM<BackfillJson>(BACKFILL_SYSTEM_PROMPT, userPrompt, llmCallContext ?? {});
+        const result = response.result;
+        if (result === null) {
+          reporter?.increment(1, { fileName: entry.relativePath });
+          continue;
+        }
+        applyBackfill(a, result, needed);
+        await saveCondensed(metaPaths, entry);
+        updated += 1;
+      } catch (cause: unknown) {
+        failed += 1;
+        logger.warn(`phase3: backfill failed for ${entry.relativePath}: ${describe(cause)}`);
+      }
+      reporter?.increment(1, { fileName: entry.relativePath });
     }
+    logger.info(`phase3 done: updated=${updated} failed=${failed}`);
+    return { updated, failed };
+  } finally {
+    reporter?.stop();
   }
-  logger.info(`phase3 done: updated=${updated} failed=${failed}`);
-  return { updated, failed };
 }
 
 function computeNeeded(a: FileAnalysis): NeededFlags {

--- a/packages/ingest-github/src/strategies/flat-folder/big-file/README.md
+++ b/packages/ingest-github/src/strategies/flat-folder/big-file/README.md
@@ -25,11 +25,15 @@ depending on chunk count and prompt budget.
   `stale-condensed`, or `missing`. Used by Phase 2 to short-circuit and by
   Phase 4 to find candidates for cheap re-condense.
 - `index.ts` — `processBigFile({knowledgeId, metaPaths, relativePath, content,
-sizeBytes, llmCallContext?})`. Sequential per file (chunk-level
-  concurrency inside). Persists every intermediate artifact, so a
-  restart resumes from the next unfinished chunk. `llmCallContext` is
-  forwarded to every chunk analyzer call so per-job LLM credentials
-  reach `@bb/llm`.
+sizeBytes, llmCallContext?, progressContext?})`. Sequential per file
+  (chunk-level concurrency inside). Persists every intermediate artifact,
+  so a restart resumes from the next unfinished chunk. `llmCallContext`
+  is forwarded to every chunk analyzer call so per-job LLM credentials
+  reach `@bb/llm`. When `progressContext` is present, the chunk pool runs
+  under a fixed-total reporter
+  (`subPhase: "big_file:<relativePath>"`, `total = chunks.length`) so
+  long single-file analyses surface as live `PHASE_TICK` envelopes
+  carrying per-chunk progress instead of looking frozen.
 
 ## Invariants
 

--- a/packages/ingest-github/src/strategies/flat-folder/big-file/index.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/big-file/index.ts
@@ -6,6 +6,7 @@ import { logger } from "@bb/logger";
 import type { ChunkAnalysisResult, HugeFileManifest } from "src/types/big-file.ts";
 import type { CondensedFileAnalysis } from "src/types/condensed-file-analysis.ts";
 import type { MetaPaths } from "src/types/meta-paths.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { throwIfCancelled } from "src/pipeline/cancellation.ts";
 import { splitFileIntoChunks } from "./chunker.ts";
 import { analyzeChunk } from "./chunk-analyzer.ts";
@@ -19,6 +20,7 @@ export interface ProcessBigFileInput {
   content: string;
   sizeBytes: number;
   llmCallContext?: AskLlmOptions;
+  progressContext?: ProgressContext;
 }
 
 export async function processBigFile(input: ProcessBigFileInput): Promise<CondensedFileAnalysis> {
@@ -30,6 +32,13 @@ export async function processBigFile(input: ProcessBigFileInput): Promise<Conden
 
   const results: ChunkAnalysisResult[] = new Array(chunks.length);
   let nextIndex = 0;
+
+  const reporter = input.progressContext?.reporter({
+    phase: "file_analysis",
+    subPhase: `big_file:${input.relativePath}`,
+    total: { kind: "fixed", total: chunks.length },
+  });
+  await reporter?.start();
 
   const worker = async (): Promise<void> => {
     while (nextIndex < chunks.length) {
@@ -43,20 +52,26 @@ export async function processBigFile(input: ProcessBigFileInput): Promise<Conden
       const cached = await loadChunkIfPresent(input.metaPaths, input.relativePath, idx);
       if (cached !== null) {
         results[idx] = cached;
+        reporter?.increment(1, { fileName: `${input.relativePath}#chunk-${String(idx)}` });
         continue;
       }
       const analyzed = await analyzeChunk(chunk, input.llmCallContext);
       await saveChunk(input.metaPaths, analyzed);
       results[idx] = analyzed;
+      reporter?.increment(1, { fileName: `${input.relativePath}#chunk-${String(idx)}` });
     }
   };
 
-  const workerCount = Math.min(concurrency, chunks.length);
-  const workers: Promise<void>[] = [];
-  for (let i = 0; i < workerCount; i += 1) {
-    workers.push(worker());
+  try {
+    const workerCount = Math.min(concurrency, chunks.length);
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < workerCount; i += 1) {
+      workers.push(worker());
+    }
+    await Promise.all(workers);
+  } finally {
+    reporter?.stop();
   }
-  await Promise.all(workers);
 
   throwIfCancelled(input.knowledgeId);
   const merged = await condenseChunks(input.relativePath, results);

--- a/packages/ingest-github/src/strategies/flat-folder/folder-summary.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/folder-summary.ts
@@ -9,6 +9,7 @@ import type { MetaPaths } from "src/types/meta-paths.ts";
 import { encodeMetaPath } from "src/pipeline/paths.ts";
 import { withConcurrency } from "src/pipeline/concurrency.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { iterateCondensed } from "./big-file/storage.ts";
 import { directFolderOf } from "./folder-path.ts";
 import { FOLDER_ANALYSIS_SYSTEM_PROMPT, folderAnalysisUserPrompt } from "./prompts/folder-summary.ts";
@@ -92,36 +93,48 @@ export async function runFolderSummaryPhase(
   knowledgeId: string,
   metaPaths: MetaPaths,
   llmCallContext?: AskLlmOptions,
+  progressContext?: ProgressContext,
 ): Promise<{ succeeded: number; failed: number }> {
   const concurrentWorkers = getConfigValue(Config.ConcurrentWorkers);
   const limit = withConcurrency(concurrentWorkers);
   const groups = await groupByDirectFolder(metaPaths);
   let succeeded = 0;
   let failed = 0;
-  const tasks: Promise<void>[] = [];
-  for (const [folderPath, files] of groups.entries()) {
-    tasks.push(
-      limit(async () => {
-        try {
-          throwIfCancelled(knowledgeId);
-          const summary = await summariseFolder(folderPath, files, llmCallContext);
-          if (summary !== null) {
-            await persistFolderSummary(metaPaths, summary);
-            succeeded += 1;
-          } else {
+  const reporter = progressContext?.reporter({
+    phase: "folder_analysis",
+    total: { kind: "fixed", total: groups.size },
+  });
+  await reporter?.start();
+  try {
+    const tasks: Promise<void>[] = [];
+    for (const [folderPath, files] of groups.entries()) {
+      tasks.push(
+        limit(async () => {
+          try {
+            throwIfCancelled(knowledgeId);
+            const summary = await summariseFolder(folderPath, files, llmCallContext);
+            if (summary !== null) {
+              await persistFolderSummary(metaPaths, summary);
+              succeeded += 1;
+            } else {
+              failed += 1;
+            }
+          } catch (cause: unknown) {
+            if (cause instanceof CancellationError) {
+              throw cause;
+            }
             failed += 1;
+            logger.warn(`phase5: folder summary failed for ${folderPath || "<root>"}`);
+          } finally {
+            reporter?.increment(1, { fileName: folderPath || "<root>" });
           }
-        } catch (cause: unknown) {
-          if (cause instanceof CancellationError) {
-            throw cause;
-          }
-          failed += 1;
-          logger.warn(`phase5: folder summary failed for ${folderPath || "<root>"}`);
-        }
-      }),
-    );
+        }),
+      );
+    }
+    await Promise.all(tasks);
+  } finally {
+    reporter?.stop();
   }
-  await Promise.all(tasks);
   logger.info(`phase5 done: foldersSummarised=${succeeded} failed=${failed}`);
   return { succeeded, failed };
 }

--- a/packages/ingest-github/src/strategies/flat-folder/index.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/index.ts
@@ -9,82 +9,110 @@ import { backfillBigFiles } from "./backfill/big-files.ts";
 import { runFolderSummaryPhase } from "./folder-summary.ts";
 import { makeRepoSummaryEnvelope, persistRepoSummary, summariseRepo } from "./repo-summary.ts";
 import { storeFlatAnalysis } from "./phases/store-flat-analysis.ts";
+import type { ProgressContext, ProgressContextFactory } from "src/progress/types.ts";
+import { nullProgressContextFactory } from "src/progress/NullProgressReporter.ts";
 
 export interface FlatFolderStrategyDeps {
   fileAnalyzer: FileAnalyzer;
+  progressContextFactory?: ProgressContextFactory;
 }
 
 export function createFlatFolderStrategy(deps: FlatFolderStrategyDeps): IngestStrategy {
+  const progressContextFactory = deps.progressContextFactory ?? nullProgressContextFactory;
   return {
     name: "flat-folder",
     async execute(input: StrategyInput): Promise<StrategyResult> {
       const { context, source, archiveSink, metaPaths, payload, branch } = input;
       const { knowledgeId, orgId, repoId, llmCallContext } = context;
+      const progressContext: ProgressContext = progressContextFactory(knowledgeId);
 
-      logger.info(`flat-folder: phase1 (classify + analyse small) starting for ${knowledgeId}`);
-      throwIfCancelled(knowledgeId);
-      const phase1Input: Parameters<typeof classifyAndAnalyseSmall>[0] = {
-        knowledgeId,
-        source,
-        metaPaths,
-        analyzer: deps.fileAnalyzer,
-      };
-      if (archiveSink !== undefined) {
-        phase1Input.archiveSink = archiveSink;
+      try {
+        progressContext.phaseChanged("file_analysis");
+
+        logger.info(`flat-folder: phase1 (classify + analyse small) starting for ${knowledgeId}`);
+        throwIfCancelled(knowledgeId);
+        const phase1Input: Parameters<typeof classifyAndAnalyseSmall>[0] = {
+          knowledgeId,
+          source,
+          metaPaths,
+          analyzer: deps.fileAnalyzer,
+          progressContext,
+        };
+        if (archiveSink !== undefined) {
+          phase1Input.archiveSink = archiveSink;
+        }
+        if (llmCallContext !== undefined) {
+          phase1Input.llmCallContext = llmCallContext;
+        }
+        const phase1 = await classifyAndAnalyseSmall(phase1Input);
+
+        logger.info(`flat-folder: phase2 (process big files) starting`);
+        throwIfCancelled(knowledgeId);
+        const phase2Input: Parameters<typeof processBigFilesQueue>[0] = {
+          knowledgeId,
+          source,
+          metaPaths,
+          progressContext,
+        };
+        if (llmCallContext !== undefined) {
+          phase2Input.llmCallContext = llmCallContext;
+        }
+        const phase2 = await processBigFilesQueue(phase2Input);
+
+        logger.info(`flat-folder: phase3 (backfill missing fields) starting`);
+        throwIfCancelled(knowledgeId);
+        await backfillMissingFields(metaPaths, llmCallContext, progressContext);
+
+        logger.info(`flat-folder: phase4 (backfill big files) starting`);
+        throwIfCancelled(knowledgeId);
+        const phase4Input: Parameters<typeof backfillBigFiles>[0] = {
+          knowledgeId,
+          source,
+          metaPaths,
+          progressContext,
+        };
+        if (llmCallContext !== undefined) {
+          phase4Input.llmCallContext = llmCallContext;
+        }
+        await backfillBigFiles(phase4Input);
+
+        progressContext.phaseChanged("folder_analysis");
+        logger.info(`flat-folder: phase5 (folder summaries) starting`);
+        throwIfCancelled(knowledgeId);
+        const phase5 = await runFolderSummaryPhase(knowledgeId, metaPaths, llmCallContext);
+
+        progressContext.phaseChanged("indexing");
+        logger.info(`flat-folder: phase6 (repo summary) starting`);
+        throwIfCancelled(knowledgeId);
+        const repoSummary = await summariseRepo(knowledgeId, metaPaths, llmCallContext);
+        let repoSummarised = false;
+        if (repoSummary !== null) {
+          await persistRepoSummary(metaPaths, makeRepoSummaryEnvelope(knowledgeId, orgId, repoSummary));
+          repoSummarised = true;
+        }
+
+        logger.info(`flat-folder: phase7 (graph store) starting`);
+        throwIfCancelled(knowledgeId);
+        const phase7 = await storeFlatAnalysis({
+          scope: { orgId, knowledgeId, repoId },
+          payload,
+          branch,
+          metaPaths,
+        });
+
+        progressContext.completed();
+
+        return {
+          filesAnalyzed: phase1.smallFilesAnalysed + phase2.processed + phase2.cached + phase1.oversizedStubs,
+          foldersSummarised: phase5.succeeded,
+          repoSummarised,
+          graphNodesWritten: phase7.nodesWritten,
+        };
+      } catch (cause: unknown) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        progressContext.failed(message);
+        throw cause;
       }
-      if (llmCallContext !== undefined) {
-        phase1Input.llmCallContext = llmCallContext;
-      }
-      const phase1 = await classifyAndAnalyseSmall(phase1Input);
-
-      logger.info(`flat-folder: phase2 (process big files) starting`);
-      throwIfCancelled(knowledgeId);
-      const phase2Input: Parameters<typeof processBigFilesQueue>[0] = { knowledgeId, source, metaPaths };
-      if (llmCallContext !== undefined) {
-        phase2Input.llmCallContext = llmCallContext;
-      }
-      const phase2 = await processBigFilesQueue(phase2Input);
-
-      logger.info(`flat-folder: phase3 (backfill missing fields) starting`);
-      throwIfCancelled(knowledgeId);
-      await backfillMissingFields(metaPaths, llmCallContext);
-
-      logger.info(`flat-folder: phase4 (backfill big files) starting`);
-      throwIfCancelled(knowledgeId);
-      const phase4Input: Parameters<typeof backfillBigFiles>[0] = { knowledgeId, source, metaPaths };
-      if (llmCallContext !== undefined) {
-        phase4Input.llmCallContext = llmCallContext;
-      }
-      await backfillBigFiles(phase4Input);
-
-      logger.info(`flat-folder: phase5 (folder summaries) starting`);
-      throwIfCancelled(knowledgeId);
-      const phase5 = await runFolderSummaryPhase(knowledgeId, metaPaths, llmCallContext);
-
-      logger.info(`flat-folder: phase6 (repo summary) starting`);
-      throwIfCancelled(knowledgeId);
-      const repoSummary = await summariseRepo(knowledgeId, metaPaths, llmCallContext);
-      let repoSummarised = false;
-      if (repoSummary !== null) {
-        await persistRepoSummary(metaPaths, makeRepoSummaryEnvelope(knowledgeId, orgId, repoSummary));
-        repoSummarised = true;
-      }
-
-      logger.info(`flat-folder: phase7 (graph store) starting`);
-      throwIfCancelled(knowledgeId);
-      const phase7 = await storeFlatAnalysis({
-        scope: { orgId, knowledgeId, repoId },
-        payload,
-        branch,
-        metaPaths,
-      });
-
-      return {
-        filesAnalyzed: phase1.smallFilesAnalysed + phase2.processed + phase2.cached + phase1.oversizedStubs,
-        foldersSummarised: phase5.succeeded,
-        repoSummarised,
-        graphNodesWritten: phase7.nodesWritten,
-      };
     },
   };
 }

--- a/packages/ingest-github/src/strategies/flat-folder/index.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/index.ts
@@ -79,7 +79,7 @@ export function createFlatFolderStrategy(deps: FlatFolderStrategyDeps): IngestSt
         progressContext.phaseChanged("folder_analysis");
         logger.info(`flat-folder: phase5 (folder summaries) starting`);
         throwIfCancelled(knowledgeId);
-        const phase5 = await runFolderSummaryPhase(knowledgeId, metaPaths, llmCallContext);
+        const phase5 = await runFolderSummaryPhase(knowledgeId, metaPaths, llmCallContext, progressContext);
 
         progressContext.phaseChanged("indexing");
         logger.info(`flat-folder: phase6 (repo summary) starting`);
@@ -98,6 +98,7 @@ export function createFlatFolderStrategy(deps: FlatFolderStrategyDeps): IngestSt
           payload,
           branch,
           metaPaths,
+          progressContext,
         });
 
         progressContext.completed();

--- a/packages/ingest-github/src/strategies/flat-folder/phases/README.md
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/README.md
@@ -10,8 +10,8 @@ and repo summarisation (Phases 5 and 6) live as `folder-summary.ts` and
 
 - `classify-and-analyse-small.ts` — Phase 1.
   `classifyAndAnalyseSmall({knowledgeId, source, metaPaths, analyzer,
-skipDecider?, archiveSink?, llmCallContext?})` walks `source.scan({
-skipDecider, llmCallContext })` and per entry:
+skipDecider?, archiveSink?, llmCallContext?, progressContext?})` walks
+  `source.scan({ skipDecider, llmCallContext })` and per entry:
   - `kind === "oversized"` → write a stub via `buildOversizedStub` +
     `saveCondensed`, and append a `too-large` row to `bigFiles.json`.
   - token count > `Config.ContextWindowLimit` → buffer a
@@ -23,12 +23,17 @@ skipDecider, llmCallContext })` and per entry:
     buffered big-file list is flushed via `writeBigFiles` after all tasks
     drain.
 - `process-big-files.ts` — Phase 2.
-  `processBigFilesQueue({knowledgeId, source, metaPaths, llmCallContext?})`
+  `processBigFilesQueue({knowledgeId, source, metaPaths, llmCallContext?, progressContext?})`
   reads `bigFiles.json`, skips `too-large` entries (counted as
   `skippedOversized`), short-circuits when `inspect` returns `complete`
   (counted as `cached`), reads the file via `source.readFile`, and
   dispatches `processBigFile` sequentially per file with the per-job
-  `llmCallContext` threaded through. Cancellation re-throws past the
+  `llmCallContext` threaded through. When `progressContext` is present
+  this phase opens a fixed-total reporter (`subPhase: "big_files_queue"`,
+  `total = entries.length`) and increments per entry — including
+  skipped/cached/failed paths so the percentage never stalls. The same
+  `progressContext` is forwarded into `processBigFile` so each big file
+  gets its own per-chunk sub-phase. Cancellation re-throws past the
   phase; other errors are logged per file and counted as `failed`.
 - `store-flat-analysis.ts` — Phase 7.
   `storeFlatAnalysis({scope, payload, branch, metaPaths})` ensures
@@ -44,8 +49,13 @@ skipDecider, llmCallContext })` and per entry:
 
 - `classifyAndAnalyseSmall(input): Promise<ClassifyPhaseResult>` —
   `{ smallFilesAnalysed, bigFilesQueued, oversizedStubs, failed }`.
+  `input.progressContext?` opens a growing-total reporter
+  (`source.scan` size is not known up front); `incrementSeen()` fires per
+  scan yield and `increment()` fires per persisted entry.
 - `processBigFilesQueue(input): Promise<ProcessBigFilesResult>` —
-  `{ processed, cached, failed, skippedOversized }`.
+  `{ processed, cached, failed, skippedOversized }`. `input.progressContext?`
+  opens a fixed-total reporter sized by `bigFiles.json` and forwards
+  itself into the per-file `processBigFile` call.
 - `storeFlatAnalysis(input): Promise<StoreFlatAnalysisResult>` —
   `{ nodesWritten, foldersWritten, filesWritten }`.
 

--- a/packages/ingest-github/src/strategies/flat-folder/phases/classify-and-analyse-small.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/classify-and-analyse-small.ts
@@ -6,6 +6,7 @@ import { getConfigValue } from "@bb/config";
 import type { ArchiveSink, FileAnalyzer, SkipDecider, SourceReader } from "src/types/pipeline.ts";
 import type { MetaPaths } from "src/types/meta-paths.ts";
 import type { BigFileEntry } from "src/types/big-file.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { withConcurrency } from "src/pipeline/concurrency.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
 import { makeSkipDecider } from "src/pipeline/skip-decisions/index.ts";
@@ -21,6 +22,7 @@ export interface ClassifyPhaseInput {
   skipDecider?: SkipDecider;
   archiveSink?: ArchiveSink;
   llmCallContext?: AskLlmOptions;
+  progressContext?: ProgressContext;
 }
 
 export interface ClassifyPhaseResult {
@@ -45,71 +47,87 @@ export async function classifyAndAnalyseSmall(input: ClassifyPhaseInput): Promis
 
   const pending: Promise<void>[] = [];
 
-  const scanDeps: Parameters<typeof input.source.scan>[0] = { skipDecider };
-  if (input.llmCallContext !== undefined) {
-    scanDeps.llmCallContext = input.llmCallContext;
-  }
-  for await (const entry of input.source.scan(scanDeps)) {
-    throwIfCancelled(input.knowledgeId);
+  const reporter = input.progressContext?.reporter({
+    phase: "file_analysis",
+    total: { kind: "growing" },
+  });
+  await reporter?.start();
 
-    if (entry.kind === "oversized") {
-      bigFileBuffer.push({
-        relativePath: entry.relativePath,
-        sizeBytes: entry.sizeBytes,
-        tokenCount: 0,
-        reason: "too-large",
-      });
-      try {
-        await saveCondensed(input.metaPaths, buildOversizedStub(entry.relativePath, entry.sizeBytes));
-        oversizedStubs += 1;
-      } catch (cause: unknown) {
-        failed += 1;
-        logger.warn(`phase1: oversized stub write failed for ${entry.relativePath}: ${describe(cause)}`);
-      }
-      continue;
+  try {
+    const scanDeps: Parameters<typeof input.source.scan>[0] = { skipDecider };
+    if (input.llmCallContext !== undefined) {
+      scanDeps.llmCallContext = input.llmCallContext;
     }
+    for await (const entry of input.source.scan(scanDeps)) {
+      throwIfCancelled(input.knowledgeId);
+      reporter?.incrementSeen();
 
-    const tokenCount = tokenLen(entry.content);
-    if (tokenCount > contextWindowLimit) {
-      bigFileBuffer.push({
-        relativePath: entry.relativePath,
-        sizeBytes: entry.sizeBytes,
-        tokenCount,
-        reason: "context-window-exceeded",
-      });
-      continue;
-    }
-
-    const fileContent = entry.content;
-    const filePath = entry.relativePath;
-    pending.push(
-      limit(async () => {
+      if (entry.kind === "oversized") {
+        bigFileBuffer.push({
+          relativePath: entry.relativePath,
+          sizeBytes: entry.sizeBytes,
+          tokenCount: 0,
+          reason: "too-large",
+        });
         try {
-          throwIfCancelled(input.knowledgeId);
-          const condensed = await analyseScannedFile(input.analyzer, entry, input.llmCallContext);
-          await saveCondensed(input.metaPaths, condensed);
-          if (input.archiveSink !== undefined) {
-            await input.archiveSink.push({
-              knowledgeId: input.knowledgeId,
-              relativePath: filePath,
-              content: fileContent,
-            });
-          }
-          smallFilesAnalysed += 1;
+          await saveCondensed(input.metaPaths, buildOversizedStub(entry.relativePath, entry.sizeBytes));
+          oversizedStubs += 1;
+          reporter?.increment(1, { fileName: entry.relativePath });
         } catch (cause: unknown) {
-          if (cause instanceof CancellationError) {
-            throw cause;
-          }
           failed += 1;
-          logger.warn(`phase1: analyse failed for ${entry.relativePath}: ${describe(cause)}`);
+          logger.warn(`phase1: oversized stub write failed for ${entry.relativePath}: ${describe(cause)}`);
         }
-      }),
-    );
+        continue;
+      }
+
+      const tokenCount = tokenLen(entry.content);
+      if (tokenCount > contextWindowLimit) {
+        bigFileBuffer.push({
+          relativePath: entry.relativePath,
+          sizeBytes: entry.sizeBytes,
+          tokenCount,
+          reason: "context-window-exceeded",
+        });
+        // Big files are accounted for here; phase 2 has its own reporter.
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
+      }
+
+      const fileContent = entry.content;
+      const filePath = entry.relativePath;
+      pending.push(
+        limit(async () => {
+          try {
+            throwIfCancelled(input.knowledgeId);
+            const condensed = await analyseScannedFile(input.analyzer, entry, input.llmCallContext);
+            await saveCondensed(input.metaPaths, condensed);
+            if (input.archiveSink !== undefined) {
+              await input.archiveSink.push({
+                knowledgeId: input.knowledgeId,
+                relativePath: filePath,
+                content: fileContent,
+              });
+            }
+            smallFilesAnalysed += 1;
+            reporter?.increment(1, { fileName: filePath });
+          } catch (cause: unknown) {
+            if (cause instanceof CancellationError) {
+              throw cause;
+            }
+            failed += 1;
+            logger.warn(`phase1: analyse failed for ${entry.relativePath}: ${describe(cause)}`);
+            reporter?.increment(1, { fileName: filePath });
+          }
+        }),
+      );
+    }
+
+    await Promise.all(pending);
+
+    await writeBigFiles(input.metaPaths, bigFileBuffer);
+  } finally {
+    reporter?.stop();
   }
-
-  await Promise.all(pending);
-
-  await writeBigFiles(input.metaPaths, bigFileBuffer);
 
   logger.info(
     `phase1 done: smallFilesAnalysed=${smallFilesAnalysed} bigFilesQueued=${bigFileBuffer.filter((e) => e.reason === "context-window-exceeded").length} oversizedStubs=${oversizedStubs} failed=${failed}`,

--- a/packages/ingest-github/src/strategies/flat-folder/phases/process-big-files.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/process-big-files.ts
@@ -2,6 +2,7 @@ import { logger } from "@bb/logger";
 import type { AskLlmOptions } from "@bb/llm";
 import type { MetaPaths } from "src/types/meta-paths.ts";
 import type { SourceReader } from "src/types/pipeline.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import { throwIfCancelled, CancellationError } from "src/pipeline/cancellation.ts";
 import { readBigFiles } from "src/strategies/flat-folder/big-file/detector.ts";
 import { inspect } from "src/strategies/flat-folder/big-file/cache.ts";
@@ -12,6 +13,7 @@ export interface ProcessBigFilesInput {
   source: SourceReader;
   metaPaths: MetaPaths;
   llmCallContext?: AskLlmOptions;
+  progressContext?: ProgressContext;
 }
 
 export interface ProcessBigFilesResult {
@@ -28,52 +30,69 @@ export async function processBigFilesQueue(input: ProcessBigFilesInput): Promise
   let failed = 0;
   let skippedOversized = 0;
 
-  for (const entry of entries) {
-    throwIfCancelled(input.knowledgeId);
-    if (entry.reason === "too-large") {
-      skippedOversized += 1;
-      continue;
-    }
-    const status = await inspect(input.metaPaths, entry.relativePath);
-    if (status === "complete") {
-      cached += 1;
-      continue;
-    }
-    let content: string;
-    try {
-      content = await input.source.readFile(entry.relativePath);
-    } catch (cause: unknown) {
-      failed += 1;
-      logger.warn(`phase2: read failed for ${entry.relativePath}: ${describe(cause)}`);
-      continue;
-    }
-    if (content.length === 0) {
-      failed += 1;
-      logger.warn(`phase2: empty content for ${entry.relativePath}; skipping`);
-      continue;
-    }
-    try {
-      await processBigFile({
-        knowledgeId: input.knowledgeId,
-        metaPaths: input.metaPaths,
-        relativePath: entry.relativePath,
-        content,
-        sizeBytes: entry.sizeBytes,
-        ...(input.llmCallContext !== undefined ? { llmCallContext: input.llmCallContext } : {}),
-      });
-      processed += 1;
-    } catch (cause: unknown) {
-      if (cause instanceof CancellationError) {
-        throw cause;
+  const reporter = input.progressContext?.reporter({
+    phase: "file_analysis",
+    subPhase: "big_files_queue",
+    total: { kind: "fixed", total: entries.length },
+  });
+  await reporter?.start();
+
+  try {
+    for (const entry of entries) {
+      throwIfCancelled(input.knowledgeId);
+      if (entry.reason === "too-large") {
+        skippedOversized += 1;
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
       }
-      failed += 1;
-      logger.warn(`phase2: processBigFile failed for ${entry.relativePath}: ${describe(cause)}`);
+      const status = await inspect(input.metaPaths, entry.relativePath);
+      if (status === "complete") {
+        cached += 1;
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
+      }
+      let content: string;
+      try {
+        content = await input.source.readFile(entry.relativePath);
+      } catch (cause: unknown) {
+        failed += 1;
+        logger.warn(`phase2: read failed for ${entry.relativePath}: ${describe(cause)}`);
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
+      }
+      if (content.length === 0) {
+        failed += 1;
+        logger.warn(`phase2: empty content for ${entry.relativePath}; skipping`);
+        reporter?.increment(1, { fileName: entry.relativePath });
+        continue;
+      }
+      try {
+        await processBigFile({
+          knowledgeId: input.knowledgeId,
+          metaPaths: input.metaPaths,
+          relativePath: entry.relativePath,
+          content,
+          sizeBytes: entry.sizeBytes,
+          ...(input.llmCallContext !== undefined ? { llmCallContext: input.llmCallContext } : {}),
+          ...(input.progressContext !== undefined ? { progressContext: input.progressContext } : {}),
+        });
+        processed += 1;
+      } catch (cause: unknown) {
+        if (cause instanceof CancellationError) {
+          throw cause;
+        }
+        failed += 1;
+        logger.warn(`phase2: processBigFile failed for ${entry.relativePath}: ${describe(cause)}`);
+      }
+      reporter?.increment(1, { fileName: entry.relativePath });
     }
+    logger.info(
+      `phase2 done: processed=${processed} cached=${cached} failed=${failed} skippedOversized=${skippedOversized}`,
+    );
+    return { processed, cached, failed, skippedOversized };
+  } finally {
+    reporter?.stop();
   }
-  logger.info(
-    `phase2 done: processed=${processed} cached=${cached} failed=${failed} skippedOversized=${skippedOversized}`,
-  );
-  return { processed, cached, failed, skippedOversized };
 }
 
 function describe(cause: unknown): string {

--- a/packages/ingest-github/src/strategies/flat-folder/phases/store-flat-analysis.ts
+++ b/packages/ingest-github/src/strategies/flat-folder/phases/store-flat-analysis.ts
@@ -8,6 +8,7 @@ import { iterateCondensed } from "src/strategies/flat-folder/big-file/storage.ts
 import { iterateFolderSummaries } from "src/strategies/flat-folder/folder-summary.ts";
 import { directFolderOf } from "src/strategies/flat-folder/folder-path.ts";
 import { languageFromPath } from "src/adapters/llm-file-analyzer.ts";
+import type { ProgressContext } from "src/progress/types.ts";
 import type { FolderSummary, RepoSummary, RepoSummaryEnvelope } from "src/strategies/flat-folder/types.ts";
 
 export interface StoreFlatAnalysisInput {
@@ -15,6 +16,7 @@ export interface StoreFlatAnalysisInput {
   payload: GithubIndexPayload;
   branch: string;
   metaPaths: MetaPaths;
+  progressContext?: ProgressContext;
 }
 
 export interface StoreFlatAnalysisResult {
@@ -59,48 +61,72 @@ export async function storeFlatAnalysis(input: StoreFlatAnalysisInput): Promise<
     nodesWritten += 1;
   }
 
+  const folderReporter = input.progressContext?.reporter({
+    phase: "indexing",
+    subPhase: "folders",
+    total: { kind: "growing" },
+  });
+  await folderReporter?.start();
   const folderPaths = new Set<string>();
-  for await (const folder of iterateFolderSummaries(input.metaPaths)) {
-    throwIfCancelled(input.scope.knowledgeId);
-    await upsertFolderNode({
-      scope: input.scope,
-      folderPath: folder.folderPath,
-      summary: shapeFolderPayload(folder),
-    });
-    folderPaths.add(folder.folderPath);
-    foldersWritten += 1;
-    nodesWritten += 1;
-  }
-
-  for await (const file of iterateCondensed(input.metaPaths)) {
-    throwIfCancelled(input.scope.knowledgeId);
-    const folderPath = directFolderOf(file.relativePath);
-    if (!folderPaths.has(folderPath)) {
+  try {
+    for await (const folder of iterateFolderSummaries(input.metaPaths)) {
+      throwIfCancelled(input.scope.knowledgeId);
+      folderReporter?.incrementSeen();
       await upsertFolderNode({
         scope: input.scope,
-        folderPath,
-        summary: emptyFolderPayload(),
+        folderPath: folder.folderPath,
+        summary: shapeFolderPayload(folder),
       });
-      folderPaths.add(folderPath);
+      folderPaths.add(folder.folderPath);
       foldersWritten += 1;
       nodesWritten += 1;
+      folderReporter?.increment(1, { fileName: folder.folderPath || "<root>" });
     }
-    await upsertFileNode({
-      orgId: input.scope.orgId,
-      knowledgeId: input.scope.knowledgeId,
-      repoId: input.scope.repoId,
-      relativePath: file.relativePath,
-      folderPath,
-      language: file.language.length > 0 ? file.language : languageFromPath(file.relativePath),
-      sha: file.sha256,
-      sizeBytes: file.sizeBytes,
-      analysis: file.analysis,
-      isBigFile: file.isBigFile,
-      totalChunks: file.totalChunks,
-      totalTokenCount: file.totalTokenCount,
-    });
-    filesWritten += 1;
-    nodesWritten += 1;
+  } finally {
+    folderReporter?.stop();
+  }
+
+  const fileReporter = input.progressContext?.reporter({
+    phase: "indexing",
+    subPhase: "files",
+    total: { kind: "growing" },
+  });
+  await fileReporter?.start();
+  try {
+    for await (const file of iterateCondensed(input.metaPaths)) {
+      throwIfCancelled(input.scope.knowledgeId);
+      fileReporter?.incrementSeen();
+      const folderPath = directFolderOf(file.relativePath);
+      if (!folderPaths.has(folderPath)) {
+        await upsertFolderNode({
+          scope: input.scope,
+          folderPath,
+          summary: emptyFolderPayload(),
+        });
+        folderPaths.add(folderPath);
+        foldersWritten += 1;
+        nodesWritten += 1;
+      }
+      await upsertFileNode({
+        orgId: input.scope.orgId,
+        knowledgeId: input.scope.knowledgeId,
+        repoId: input.scope.repoId,
+        relativePath: file.relativePath,
+        folderPath,
+        language: file.language.length > 0 ? file.language : languageFromPath(file.relativePath),
+        sha: file.sha256,
+        sizeBytes: file.sizeBytes,
+        analysis: file.analysis,
+        isBigFile: file.isBigFile,
+        totalChunks: file.totalChunks,
+        totalTokenCount: file.totalTokenCount,
+      });
+      filesWritten += 1;
+      nodesWritten += 1;
+      fileReporter?.increment(1, { fileName: file.relativePath });
+    }
+  } finally {
+    fileReporter?.stop();
   }
 
   logger.info(`phase7 done: nodesWritten=${nodesWritten} folders=${foldersWritten} files=${filesWritten}`);

--- a/packages/ingest-github/types/index.d.ts
+++ b/packages/ingest-github/types/index.d.ts
@@ -1,7 +1,38 @@
 export interface RegisterGithubWorkersDeps {
   sourceFactory?: SourceFactory;
   pullFactory?: PullFactory;
+  progressContextFactory?: ProgressContextFactory;
 }
+
+export type ProgressPhase = "file_analysis" | "folder_analysis" | "indexing";
+
+export type ProgressTotalMode = { kind: "fixed"; total: number } | { kind: "growing"; initialTotal?: number };
+
+export interface ProgressReporterInput {
+  readonly phase: ProgressPhase;
+  readonly subPhase?: string;
+  readonly total: ProgressTotalMode;
+  readonly resolveInitialProcessed?: () => Promise<number> | number;
+}
+
+export interface ProgressReporter {
+  start(): Promise<void>;
+  increment(delta?: number, meta?: { fileName?: string }): void;
+  incrementSeen(delta?: number): void;
+  setTotal(total: number): void;
+  stop(): void;
+}
+
+export interface ProgressContext {
+  reporter(input: ProgressReporterInput): ProgressReporter;
+  phaseChanged(phase: ProgressPhase): void;
+  completed(message?: string): void;
+  failed(error: string, phase?: ProgressPhase): void;
+}
+
+export type ProgressContextFactory = (knowledgeId: string) => ProgressContext;
+
+export declare const nullProgressContextFactory: ProgressContextFactory;
 
 export declare function registerGithubWorkers(deps?: RegisterGithubWorkersDeps): void;
 export declare function registerLocalIngestWorker(): void;


### PR DESCRIPTION
[TEST] feature/progress-factory — progress reporting extension port for flat-folder strategy

## What changed

- Added `@bb/ingest-github/progress` extension port: `ProgressContext`, `ProgressContextFactory`, `ProgressReporter`, `ProgressPhase`, `ProgressTotalMode`, `ProgressReporterInput` (see [packages/ingest-github/src/progress/types.ts](ext/ingestion-engine-public/packages/ingest-github/src/progress/types.ts)).
- Shipped `NullProgressReporter` + `nullProgressContextFactory` as the default no-op sink so the OSS binary stays consistent with the no-outbound-calls posture.
- Threaded an optional `progressContextFactory` through `registerGithubWorkers`, `buildRunner`, and the pull worker; defaults to the null factory when the host does not supply one.
- Plumbed progress reporters into the flat-folder strategy phases: `classify-and-analyse-small`, `process-big-files`, `analyse-changed`, plus the `backfill/big-files` and `backfill/fields` sub-phases — each emits start / increment / setTotal / stop around its real work unit (files, folders, indexing).
- Exported the progress types and the null factory from `@bb/ingest-github/index.ts` so a host binary (e.g. a future hosted variant) can implement transport without forking the strategy.
- Updated `packages/ingest-github/README.md`, `src/progress/README.md`, `src/pipeline/README.md`, `src/strategies/flat-folder/README.md`, `phases/README.md`, `backfill/README.md`, and `big-file/README.md` to document the new port and per-phase emission points.
- Added `types/index.d.ts` to expose the public progress surface alongside the existing pipeline types.

## Why

The flat-folder strategy runs long phases (per-file LLM analysis, big-file backfills, folder roll-ups) and a host process needs to observe phase progress without the strategy importing transport (SSE, WebSocket, BullMQ events, etc.). Embedding a transport in `@bb/ingest-github` would violate tier discipline and the no-outbound-calls rule of the OSS binary.

This change adds a host-supplied port so:

- The OSS `bytebell-server` keeps emitting nothing (null reporter), preserving the local-first posture.
