### PR TITLE
fix: surface processing errors in terminal (#65)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bytebell-public",

--- a/packages/cli/src/IndexCommand.ts
+++ b/packages/cli/src/IndexCommand.ts
@@ -83,6 +83,11 @@ interface RepoStatus {
   fileCount: number;
   totalFiles?: number;
   processedFiles?: number;
+  failure?: {
+    reason: string;
+    category: string;
+    detail?: string;
+  };
 }
 
 async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> {
@@ -113,11 +118,19 @@ async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> 
         return;
       }
       if (status.state === "FAILED") {
+        const failMsg = `Indexing failed for ${knowledgeId}`;
         if (bar) {
-          bar.stop(false, `Indexing failed for ${knowledgeId}`);
+          bar.stop(false, failMsg);
         } else {
-          spinner.stop(false, `Indexing failed for ${knowledgeId}`);
+          spinner.stop(false, failMsg);
         }
+        if (status.failure?.reason !== undefined) {
+          error(`Reason: ${status.failure.reason}`);
+        }
+        if (status.failure?.detail !== undefined) {
+          error(`Detail: ${status.failure.detail}`);
+        }
+        process.exitCode = 1;
         return;
       }
     } catch (cause: unknown) {

--- a/packages/server/src/reposRoute.ts
+++ b/packages/server/src/reposRoute.ts
@@ -39,6 +39,7 @@ export function buildReposRoute(): Router {
       fileCount: entry.fileCount,
       totalFiles: entry.status.totalFiles,
       processedFiles: entry.status.processedFiles,
+      ...(entry.failure !== undefined ? { failure: entry.failure } : {}),
     });
   });
 


### PR DESCRIPTION
# [TEST] bugfix/issue-65-surface-errors — surface processing errors in the terminal
 
## What changed
 
- **Failure reasons are now printed in the CLI.** When `bytebell index <repo>` fails during processing, the CLI now prints the failure `reason` and `detail` directly to the terminal instead of exiting silently.
- **Surfaced the persisted error state.** The failure information already recorded for a knowledge entry (e.g. the provider error returned during the analyse phase) is now read back and shown to the user at the end of a failed run, rather than only living in the datastore/logs.
- Touched files:
  - `packages/cli/src/IndexCommand.ts` — render the failure `reason` / `detail` on a failed index run.
  - `packages/server/src/reposRoute.ts` — expose the failure information so the CLI can read and display it.

## Why
 
Reported in **issue #65**: `bytebell index {repo_url}` could fail with **no reason populated in the terminal**. The run would end (or appear to hang/time out) without telling the user *why* it failed, forcing them to dig through `~/.bytebell/logs/` to find the cause.
 
 
```
✗ Indexing failed for <knowledge-id>
✗ Reason: LLM provider rejected the API key. Update the key and retry.
✗ Detail: {"error":{"message":"User not found.","code":401}}
```
 
— instead of the previous silent failure.
 
Linked issue: Closes #65
 
## How to test
 
1. Ensure the project builds and validation checks pass:
   ```
   bun run typecheck
   bun run lint
   bun run format:check
   ```
 
2. Boot the stack and trigger a failing index run:
   ```
   bytebell boot
   bytebell index https://github.com/sindresorhus/is-odd --verbose
   ```
 
3. Force a failure to verify the error surfaces. The simplest way is to point the LLM provider at an invalid/unfunded OpenRouter key, then index:
   ```
   bytebell set openrouter-api-key sk-or-v1-invalid-key
   bytebell shutdown
   bytebell boot
   bytebell index https://github.com/Amar07Singh/Local-Auth-Layer-for-AI-Agents --verbose
   ```
 
4. **Expected result:** instead of failing silently, the terminal prints the failure reason and detail, e.g.:
   ```
   ✗ Indexing failed for <knowledge-id>
   ✗ Reason: LLM provider rejected the API key. Update the key and retry.
   ✗ Detail: {"error":{"message":"...","code":401}}
   ```
 
5. **Regression check (happy path):** restore a valid, funded key/model and confirm a normal run still completes without spurious error output:
   ```
   bytebell set openrouter-api-key <valid-key>
   bytebell set openrouter-model anthropic/claude-3.5-haiku
   bytebell shutdown
   bytebell boot
   bytebell index https://github.com/sindresorhus/is-odd --verbose
   bytebell ls      # row should reach PROCESSED with no error printed
   ```
 
## Checklist
 
- [x] Branch name follows the naming rules
- [x] Title starts with a status tag
- [x] Description has **What / Why / How to test** sections
- [ ] Screenshots attached (N/A — CLI-only change, no UI)
- [x] All CI checks pass (typecheck, lint, format)
- [x] Self-reviewed the diff — no leftover debug logs, commented-out code, or secrets
- [ ] Rebased against the target branch so the diff is clean
 