### PR TITLE
fix: surface processing errors in terminal (#65)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bytebell-public",

--- a/packages/cli/src/IndexCommand.ts
+++ b/packages/cli/src/IndexCommand.ts
@@ -83,6 +83,11 @@ interface RepoStatus {
   fileCount: number;
   totalFiles?: number;
   processedFiles?: number;
+  failure?: {
+    reason: string;
+    category: string;
+    detail?: string;
+  };
 }
 
 async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> {
@@ -113,11 +118,19 @@ async function pollJobStatus(knowledgeId: string, jobId: string): Promise<void> 
         return;
       }
       if (status.state === "FAILED") {
+        const failMsg = `Indexing failed for ${knowledgeId}`;
         if (bar) {
-          bar.stop(false, `Indexing failed for ${knowledgeId}`);
+          bar.stop(false, failMsg);
         } else {
-          spinner.stop(false, `Indexing failed for ${knowledgeId}`);
+          spinner.stop(false, failMsg);
         }
+        if (status.failure?.reason !== undefined) {
+          error(`Reason: ${status.failure.reason}`);
+        }
+        if (status.failure?.detail !== undefined) {
+          error(`Detail: ${status.failure.detail}`);
+        }
+        process.exitCode = 1;
         return;
       }
     } catch (cause: unknown) {

--- a/packages/server/src/reposRoute.ts
+++ b/packages/server/src/reposRoute.ts
@@ -39,6 +39,7 @@ export function buildReposRoute(): Router {
       fileCount: entry.fileCount,
       totalFiles: entry.status.totalFiles,
       processedFiles: entry.status.processedFiles,
+      ...(entry.failure !== undefined ? { failure: entry.failure } : {}),
     });
   });
 


### PR DESCRIPTION
# [TEST] bugfix/issue-65-surface-errors — show the error when indexing fails

## What changed

When `bytebell index <repo>` fails, the CLI now prints why it failed right in the terminal. Before, the run just ended with no explanation and you had to dig through `~/.bytebell/logs/` to find the cause.

The failure reason was already being recorded — this change just reads it back and shows it at the end of a failed run.

Files changed:
- `packages/cli/src/IndexCommand.ts` — print the reason and detail on failure.
- `packages/server/src/reposRoute.ts` — send that info back so the CLI can show it.

## Why

Issue #65: a failed index gave no reason in the terminal. Now you see the actual cause, for example:

```
✗ Indexing failed for <knowledge-id>
✗ Reason: LLM provider rejected the API key. Update the key and retry.
✗ Detail: {"error":{"message":"User not found.","code":401}}
```

Closes #65

## How to test

1. Check it builds:
   ```
   bun run typecheck
   bun run lint
   bun run format:check
   ```

2. Make an index run fail on purpose by setting a bad key:
   ```
   bytebell set openrouter-api-key sk-or-v1-invalid-key
   bytebell shutdown
   bytebell boot
   bytebell index https://github.com/sindresorhus/is-odd --verbose
   ```
   Expected: the terminal prints the reason and detail instead of failing silently.

3. Then set a valid key and confirm a normal run still works with no error printed:
   ```
   bytebell set openrouter-api-key <valid-key>
   bytebell set openrouter-model anthropic/claude-3.5-haiku
   bytebell shutdown
   bytebell boot
   bytebell index https://github.com/sindresorhus/is-odd --verbose
   bytebell ls      # should reach PROCESSED, no error
   ```