### PR TITLE
feat: boot opens setup form when OpenRouter keys are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ See [commands.md](commands.md) for install steps. Once installed, verify with `b
 
 ### Configure
 
-Two values to set yourself — everything else is auto-provisioned on first boot:
+Two values Bytebell needs — your OpenRouter API key and model. Set them headlessly:
 
 ```bash
 bytebell set openrouter-api-key sk-or-…
 bytebell set openrouter-model anthropic/claude-sonnet-4.6
 ```
+
+Or skip this step and run `bytebell boot` straight away — on an interactive terminal it opens a setup form to collect these on first run. Running `bytebell set` with no arguments opens the same form at any time.
 
 There is no `.env` file anywhere. `~/.bytebell/config.json` (mode `0600`) is the single source of truth, and `bytebell set` is the only sanctioned way to write to it. If you already run Mongo / Neo4j / Redis and don't want the Docker stack, see [Bring your own infrastructure](#bring-your-own-infrastructure) below.
 
@@ -33,7 +35,7 @@ bytebell boot
 
 What happens, in order:
 
-1. **Pre-flight check** — refuses to start if either OpenRouter key is blank.
+1. **Pre-flight check** — verifies both OpenRouter keys are set. If either is blank and you're in an interactive terminal, Bytebell opens a setup form so you can enter them on the spot, then continues. In a non-interactive context (CI, piped input) it prints the exact `bytebell set …` commands and exits.
 2. **Auto-fill** — fills any missing infra config keys with local-Docker defaults; generates a Neo4j password if one isn't set.
 3. **Stack up** — `docker compose up -d` brings up `bytebell-mongo`, `bytebell-neo4j`, `bytebell-redis` (named volumes — data persists across reboots).
 4. **Health gate** — polls `docker compose ps` until all three services report `healthy`.
@@ -223,7 +225,7 @@ Settings live in `~/.bytebell/config.json` and are written exclusively by `byteb
 | `log-level`          | Winston log level                        | `info`                               |
 | `log-retention-days` | Daily log retention                      | `14`                                 |
 
-If a piece of infra is missing, the server prints the exact `bytebell set …` command you need and refuses to boot — it never silently reads `process.env`.
+If a required setting is missing, Bytebell either opens the setup form (interactive terminal) or prints the exact `bytebell set …` command and refuses to boot (non-interactive). It never silently reads `process.env`.
 
 ## Why this design — research grounding
 

--- a/packages/cli/src/BootCommand.ts
+++ b/packages/cli/src/BootCommand.ts
@@ -56,13 +56,14 @@ async function runBoot(): Promise<void> {
     info(`dev mode: logs → ${process.cwd()}/logs/`);
   }
 
-  if (defaults.neo4jPassword.length === 0) {
-    error("internal: neo4j password is empty after applyInfraDefaults — refusing to start docker.");
+  const neo4jPassword = getConfigValue(Config.Neo4jPassword);
+  if (neo4jPassword.length === 0) {
+    error("internal: neo4j password is empty after setup — refusing to start docker.");
     process.exitCode = 1;
     return;
   }
 
-  const upResult = await bringInfraUp(defaults.neo4jPassword);
+  const upResult = await bringInfraUp(neo4jPassword);
   if (upResult === null) {
     return;
   }

--- a/packages/cli/src/BootCommand.ts
+++ b/packages/cli/src/BootCommand.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only WITH non-commercial-clause
 import { Command } from "commander";
+import React from "react";
+import { render } from "ink";
 import { Config } from "@bb/types";
 import { HINTS, getConfigValue, isDevMode } from "@bb/config";
 import { applyInfraDefaults, checkPreflight } from "./bootConfig.ts";
+import { SetupForm } from "./SetupForm.tsx";
 import {
   DockerComposeError,
   DockerHealthTimeoutError,
@@ -35,15 +38,6 @@ export function buildBootCommand(): Command {
 }
 
 async function runBoot(): Promise<void> {
-  if (!enforcePreflight()) {
-    process.exitCode = 1;
-    return;
-  }
-
-  if (isDevMode()) {
-    info(`dev mode: logs → ${process.cwd()}/logs/`);
-  }
-
   const defaults = applyInfraDefaults();
   for (const entry of defaults.written) {
     if (entry.redacted) {
@@ -51,6 +45,15 @@ async function runBoot(): Promise<void> {
     } else {
       success(`set ${entry.cliKey} (auto-filled with local-docker default)`);
     }
+  }
+
+  if (!(await ensurePreflight())) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (isDevMode()) {
+    info(`dev mode: logs → ${process.cwd()}/logs/`);
   }
 
   if (defaults.neo4jPassword.length === 0) {
@@ -232,15 +235,40 @@ async function startServer(): Promise<boolean> {
   }
 }
 
-function enforcePreflight(): boolean {
-  const result = checkPreflight();
-  if (result.ok) {
+async function ensurePreflight(): Promise<boolean> {
+  const initial = checkPreflight();
+  if (initial.ok) {
     return true;
   }
-  for (const entry of result.missing) {
+  if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
+    reportMissing(initial.missing);
+    return false;
+  }
+  info("Bytebell needs a few settings before first boot — opening setup form…");
+  const saved = await renderSetupForm();
+  if (!saved) {
+    return false;
+  }
+  const after = checkPreflight();
+  if (after.ok) {
+    return true;
+  }
+  reportMissing(after.missing);
+  return false;
+}
+
+function reportMissing(missing: ReturnType<typeof checkPreflight>["missing"]): void {
+  for (const entry of missing) {
     error(`${entry.hintKey} is not set`, HINTS[entry.configKey]);
   }
-  return false;
+}
+
+async function renderSetupForm(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const onDone = (result: { saved: boolean }): void => resolve(result.saved);
+    const { waitUntilExit } = render(React.createElement(SetupForm, { onDone }));
+    waitUntilExit().catch(() => resolve(false));
+  });
 }
 
 function handleDockerError(cause: unknown): void {

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -26,8 +26,10 @@ package-level contract; this file documents how the source tree is split.
   headlessly today, including `openrouter-api-key` (`redact: true`)
   and `openrouter-model` (plain text).
 - **[BootCommand.ts](BootCommand.ts)** — the `boot` subcommand.
-  Sequence: `checkPreflight` (errors out with `HINTS` if openrouter
-  api-key/model are blank) → `applyInfraDefaults` (auto-fills the
+  Sequence: `ensurePreflight` (if openrouter api-key/model are blank,
+  renders `<SetupForm />` when stdin+stdout are a TTY so the user can
+  fill them in-place; falls back to the legacy print-`HINTS`-and-exit
+  path on non-TTY for CI) → `applyInfraDefaults` (auto-fills the
   blank infra keys, generates a random Neo4j password if needed) →
   `dockerInfra.up` (writes `.env`, runs compose, polls health) →
   `ensureServerRunning` (existing helper that lazy-spawns the server
@@ -70,14 +72,18 @@ package-level contract; this file documents how the source tree is split.
   view shows `•••…` for masked rows. Renders an inline red error line
   underneath when the field's `validate` returns a non-null string.
 - **[SetupForm.tsx](SetupForm.tsx)** — the Ink form rendered by
-  `bytebell set` no-args. Six rows declared in a `ROWS` constant: Mongo
-  URI / Neo4j URI / Neo4j user / Neo4j password (masked) / Redis URL /
-  Server port. Each row carries its own format-only `validate` regex.
-  State: a single `useState<Record<string,string>>` keyed by row id and
-  seeded from `loadConfig()` so users see and edit existing settings.
-  Navigation via Ink's built-in `useFocusManager` (Tab / Shift-Tab). On
-  Enter when all rows pass validation, iterates the dispatch table in
-  row order calling `entry.setter(value)`. On Esc, exits without saving.
+  `bytebell set` no-args **and** by `bytebell boot` when openrouter
+  keys are missing on an interactive TTY. Nine rows declared in a
+  `ROWS` constant: Mongo URI / Neo4j URI / Neo4j user / Neo4j password
+  (masked) / Redis URL / Server port / GitHub Concurrency / OpenRouter
+  API key (masked) / OpenRouter model. Each row carries its own
+  format-only `validate` regex (or non-empty check for the openrouter
+  rows). State: a single `useState<Record<string,string>>` keyed by
+  row id and seeded from `loadInitial()` so users see and edit
+  existing settings. Navigation via Ink's built-in `useFocusManager`
+  (Tab / Shift-Tab). On Enter when all rows pass validation, iterates
+  the dispatch table in row order calling `entry.setter(value)`. On
+  Esc, exits without saving.
 
 ## Module dependency graph
 
@@ -94,8 +100,9 @@ SetCommand.ts      → commander, react, ink (render), @bb/config (HINTS),
 bootConfig.ts      → node:crypto, @bb/types (Config), @bb/config (getConfigValue),
                      keyMap.ts (KEY_MAP)
 dockerInfra.ts     → node:child_process, node:fs/promises, node:path, node:url
-BootCommand.ts     → commander, @bb/types (Config), @bb/config (HINTS, getConfigValue),
-                     bootConfig.ts, dockerInfra.ts, serverSpawn.ts, output.ts
+BootCommand.ts     → commander, react, ink (render), @bb/types (Config),
+                     @bb/config (HINTS, getConfigValue), bootConfig.ts, dockerInfra.ts,
+                     serverSpawn.ts, SetupForm.tsx (SetupForm), output.ts
 ShutdownCommand.ts → commander, node:fs/promises, node:path, @bb/config (getBytebellHome),
                      dockerInfra.ts (composeFilePath), output.ts
 

--- a/packages/cli/src/SetupForm.tsx
+++ b/packages/cli/src/SetupForm.tsx
@@ -57,6 +57,19 @@ const ROWS: Row[] = [
     cliKey: "concurrency.github",
     validate: (s) => (/^\d+$/u.test(s) && Number(s) > 0 ? null : "expected positive integer"),
   },
+  {
+    id: "openrouter-api-key",
+    label: "OpenRouter API key",
+    cliKey: "openrouter-api-key",
+    mask: true,
+    validate: (s) => (s.length > 0 ? null : "required — get one at openrouter.ai/keys"),
+  },
+  {
+    id: "openrouter-model",
+    label: "OpenRouter model",
+    cliKey: "openrouter-model",
+    validate: (s) => (s.length > 0 ? null : "required — e.g. deepseek/deepseek-v4-flash"),
+  },
 ];
 
 function loadInitial(): Record<string, string> {
@@ -68,6 +81,8 @@ function loadInitial(): Record<string, string> {
     redis: getConfigValue(Config.RedisUrl),
     port: String(getConfigValue(Config.ServerPort)),
     "concurrency-github": String(getConfigValue(Config.ConcurrencyGithub)),
+    "openrouter-api-key": getConfigValue(Config.OpenrouterApiKey),
+    "openrouter-model": getConfigValue(Config.OpenrouterModel),
   };
 }
 


### PR DESCRIPTION
# What changed

Setup form now has two new fields: OpenRouter API key (masked) and OpenRouter model. Pre-filled from config.

`bytebell boot` behavior when API key is missing:
- TTY: opens the form to fill it in
- Non-TTY (scripts/CI): exits with the original error

Updated `packages/cli/src/README.md`.

# Why

**Easier first-run:** New user runs `bytebell boot` → form pops up → they fill in the key → boot works. Done. No reading docs, no running commands multiple times.

**Safe for scripts:** Scripts and CI jobs still get the error message, no surprise UI in the middle of a pipeline.

# Linked issue

Fixes #82

# How to test


**1. Form opens on missing key**
```powershell
$c = Get-Content $env:USERPROFILE\.bytebell\config.json | ConvertFrom-Json
$c.openrouter_api_key = ""; $c | ConvertTo-Json | Set-Content $env:USERPROFILE\.bytebell\config.json
bytebell boot
```
Expect: form opens, API key field empty with "required" hint.

**2. Esc cancels cleanly**
With form open, press Esc. Expect: exits, no Docker started.

**3. Pre-set keys skip the form**
```powershell
bytebell set openrouter-api-key "sk-or-v1-test"
bytebell set openrouter-model "anthropic/claude-3.5-haiku"
bytebell boot
```
Expect: no form, boots straight to Docker.