### PR TITLE
feat: Add GitLab support with subgroup-aware URL parsing and update documentation

### DIFF
--- a/packages/ingest-github/src/README.md
+++ b/packages/ingest-github/src/README.md
@@ -66,11 +66,14 @@ Domain (composes infra: `@bb/config`, `@bb/llm`, `@bb/mongo`, `@bb/neo4j`,
   that route through this pipeline via an injected `SourceFactory`. The
   kernel `RepoLocation` only has a `github` provider variant today; gitlab
   projects therefore share the github path segment on disk. Subgroup gitlab
-  URLs (`group/sub/project`) collapse to `{ owner: group, repo: sub }` here
-  — consumers that need the full namespace derive it themselves (the GitLab
-  source-factory does this when building its own `RepoLocation`). The same
-  loosening is mirrored in the kernel duplicate `parseGithubOwnerRepo` in
-  `@bb/types/src/path-layout.ts` so both implementations stay consistent.
+  URLs (`group/sub/project`) collapse to `{ owner: group, repo: sub }` in
+  this pull-only helper. For the knowledgeId-keyed resolver
+  ([pipeline/paths.ts](pipeline/paths.ts) `repoLocationFor`) — which the
+  business-context reader uses — gitlab.com URLs now go through the
+  subgroup-aware `parseGitlabOwnerRepo` in `@bb/types/src/path-layout.ts`
+  (`owner="group/sub"`, `repo="project"`) so the read path matches the GitLab
+  source-factory's `deriveOwnerRepo` and resolves the same on-disk directory
+  for nested projects.
 - **[README.md](README.md)** — this file.
 
 ## Subtrees

--- a/packages/ingest-github/src/pipeline/paths.ts
+++ b/packages/ingest-github/src/pipeline/paths.ts
@@ -8,6 +8,7 @@ import {
   metaOutputRootFor,
   orgsRootFor,
   parseGithubOwnerRepo,
+  parseGitlabOwnerRepo,
   repositoryDirFor,
   type RepoLocation as KernelRepoLocation,
 } from "@bb/types";
@@ -122,7 +123,11 @@ async function repoLocationFor(knowledgeId: string, commitHash?: string): Promis
   if (repoUrl === undefined || repoUrl.length === 0) {
     throw new Error(`paths: knowledge ${knowledgeId} has no info.repoUrl`);
   }
-  const parsed = parseGithubOwnerRepo(repoUrl);
+  // GitLab projects can be nested in subgroups, so its owner/repo derivation
+  // differs from GitHub (subgroups collapse into the owner namespace). Both
+  // providers share the on-disk `provider: "github"` segment — the GitLab
+  // ingester writes there too — so only the owner/repo split is host-specific.
+  const parsed = repoUrl.includes("gitlab.com") ? parseGitlabOwnerRepo(repoUrl) : parseGithubOwnerRepo(repoUrl);
   if (parsed === null) {
     throw new Error(`paths: could not parse owner/repo from ${repoUrl}`);
   }

--- a/packages/types/src/README.md
+++ b/packages/types/src/README.md
@@ -95,10 +95,13 @@ lastAttemptAt }`) plus `EnrichmentFailureReason` (`"cap-exceeded" |
   hostnames so the path resolver can build a `RepoLocation` for GitLab
   knowledges routed through the GitHub pipeline via an injected
   `SourceFactory`; the union still only has a `github` provider variant,
-  so gitlab projects share the github path segment on disk. Subgroup
-  gitlab URLs (`group/sub/project`) collapse to two segments here — the
-  GitLab factory derives the full namespace itself when building its own
-  `RepoLocation`. The `MetaPathsLayout` interface
+  so gitlab projects share the github path segment on disk. For
+  subgroup-aware gitlab URLs (`group/sub/project`) use the companion
+  `parseGitlabOwnerRepo(repoUrl)`, which collapses every segment except
+  the last into the `owner` namespace (`owner="group/sub"`,
+  `repo="project"`) — matching `deriveOwnerRepo` in the GitLab
+  `SourceFactory`, so the ingest-write and business-context-read disk
+  paths agree for nested projects. The `MetaPathsLayout` interface
   documents the leaf-path shape returned by `bytebellPathsFor`. Lives
   here so `@bb/ingest-github` (writer) and `@bb/mcp` (reader) can
   agree on the layout without one importing the other.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -57,5 +57,6 @@ export {
   metaOutputRootFor,
   bytebellPathsFor,
   parseGithubOwnerRepo,
+  parseGitlabOwnerRepo,
 } from "./path-layout.ts";
 export type { RepoLocation, MetaPathsLayout } from "./path-layout.ts";

--- a/packages/types/src/path-layout.ts
+++ b/packages/types/src/path-layout.ts
@@ -133,3 +133,39 @@ export function parseGithubOwnerRepo(repoUrl: string): { owner: string; repo: st
     return null;
   }
 }
+
+/**
+ * Pure URL parser for GitLab repo URLs that preserves subgroups. GitLab
+ * projects can be nested arbitrarily deep (`group/subgroup/project`); the
+ * canonical project path is "everything up to the last segment as the owner
+ * namespace, last segment as the repo". Returns `null` for non-gitlab.com
+ * hosts or paths with fewer than two segments.
+ *
+ * This MUST stay consistent with `deriveOwnerRepo` in
+ * `@bytebell/.../ingest-gitlab/src/source-factory.ts`, which is what the GitLab
+ * ingester uses to choose the on-disk `<owner>/<repo>` directory segments. The
+ * business-context reader resolves the same path via `repoLocationFor`, so the
+ * two derivations must agree or enrichment reads miss the directory.
+ */
+export function parseGitlabOwnerRepo(repoUrl: string): { owner: string; repo: string } | null {
+  if (repoUrl.length === 0) {
+    return null;
+  }
+  try {
+    const url = new URL(repoUrl);
+    if (!url.hostname.endsWith("gitlab.com")) {
+      return null;
+    }
+    const segments = url.pathname.split("/").filter((s) => s.length > 0);
+    if (segments.length < 2) {
+      return null;
+    }
+    const repoRaw = segments[segments.length - 1];
+    if (repoRaw === undefined) {
+      return null;
+    }
+    return { owner: segments.slice(0, -1).join("/"), repo: repoRaw.replace(/\.git$/u, "") };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- custom context blocker removed