### PR TITLE
fix(security): encrypt API key in config file (#100)

### DIFF
--- a/packages/config/src/crypto.ts
+++ b/packages/config/src/crypto.ts
@@ -1,0 +1,115 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const SALT = "bytebell-config-encryption-v1";
+
+/**
+ * Derives an encryption key from machine-specific identifiers.
+ * This ensures encrypted config is tied to this machine.
+ */
+function deriveKey(): Buffer {
+  // Use machine-specific values that are stable but not easily portable
+  const hostname = os.hostname();
+  const username = os.userInfo().username;
+  const platform = os.platform();
+  // Combine with a fixed salt for consistency
+  const material = `${hostname}:${username}:${platform}:${SALT}`;
+  return crypto.scryptSync(material, SALT, 32);
+}
+
+/**
+ * Encrypts a string value using AES-256-GCM.
+ * Returns a prefixed string so we can detect encrypted values.
+ */
+export function encryptValue(plaintext: string): string {
+  if (!plaintext) return plaintext;
+
+  const key = deriveKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(plaintext, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag().toString("hex");
+
+  // Format: enc:iv:authTag:ciphertext (all hex-encoded)
+  return `enc:${iv.toString("hex")}:${authTag}:${encrypted}`;
+}
+
+/**
+ * Decrypts a value encrypted with encryptValue().
+ * Returns the plaintext string.
+ */
+export function decryptValue(encryptedValue: string): string {
+  if (!encryptedValue || !encryptedValue.startsWith("enc:")) {
+    // Not encrypted — return as-is (backward compatibility)
+    return encryptedValue;
+  }
+
+  const parts = encryptedValue.split(":");
+  if (parts.length !== 4) {
+    throw new Error("Invalid encrypted value format");
+  }
+
+  const [, ivHex, authTagHex, ciphertext] = parts;
+  const key = deriveKey();
+  const iv = Buffer.from(ivHex, "hex");
+  const authTag = Buffer.from(authTagHex, "hex");
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(ciphertext, "hex", "utf8");
+  decrypted += decipher.final("utf8");
+
+  return decrypted;
+}
+
+/**
+ * Encrypts sensitive fields in a config object.
+ * Returns a new object with encrypted values.
+ */
+export function encryptSensitiveFields(config: Record<string, unknown>): Record<string, unknown> {
+  const SENSITIVE_KEYS = [
+    "openrouter_api_key",
+    "neo4j_password",
+    // Add other sensitive fields here
+  ];
+
+  const result = { ...config };
+  for (const key of SENSITIVE_KEYS) {
+    if (typeof result[key] === "string" && result[key] && !String(result[key]).startsWith("enc:")) {
+      result[key] = encryptValue(String(result[key]));
+    }
+  }
+  return result;
+}
+
+/**
+ * Decrypts sensitive fields in a config object.
+ * Returns a new object with decrypted values.
+ */
+export function decryptSensitiveFields(config: Record<string, unknown>): Record<string, unknown> {
+  const SENSITIVE_KEYS = [
+    "openrouter_api_key",
+    "neo4j_password",
+  ];
+
+  const result = { ...config };
+  for (const key of SENSITIVE_KEYS) {
+    if (typeof result[key] === "string" && String(result[key]).startsWith("enc:")) {
+      try {
+        result[key] = decryptValue(String(result[key]));
+      } catch {
+        // If decryption fails, keep the value as-is
+        // This handles cases where the machine key changed
+      }
+    }
+  }
+  return result;
+}

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { decryptSensitiveFields } from "./crypto.ts";
 import {
   configSchema,
   Config,
@@ -43,7 +44,8 @@ export function loadConfig(): BytebellConfig {
   ensureBytebellHome();
   const raw = fs.readFileSync(getConfigPath(), "utf8");
   const parsed: unknown = JSON.parse(raw);
-  cached = configSchema.parse(parsed);
+  const decrypted = decryptSensitiveFields(parsed as Record<string, unknown>);
+  cached = configSchema.parse(decrypted);
   return cached;
 }
 

--- a/packages/config/src/writer.ts
+++ b/packages/config/src/writer.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { configSchema, Config, type BytebellConfig, type ConfigValue, DEFAULT_CONFIG, writeField } from "./schema.ts";
+import { encryptSensitiveFields } from "./crypto.ts";
 import { __isSeeded } from "./loader.ts";
 import { getBytebellHome, getConfigPath, __notifyConfigChanged } from "./paths.ts";
 
@@ -22,7 +23,8 @@ function readConfigFile(): BytebellConfig {
 function atomicWrite(cfg: BytebellConfig): void {
   const target = getConfigPath();
   const tmp = `${target}.tmp`;
-  const json = `${JSON.stringify(cfg, null, 2)}\n`;
+  const encrypted = encryptSensitiveFields(cfg as Record<string, unknown>);
+  const json = `${JSON.stringify(encrypted, null, 2)}\n`;
   const fd = fs.openSync(tmp, "w", FILE_MODE);
   try {
     fs.writeSync(fd, json);


### PR DESCRIPTION
Fixes #100## Problem`openrouter_api_key` is stored as plaintext in `~/.bytebell/config.json`. Any process running as the same OS user can read it.## SolutionEncrypts sensitive fields using AES-256-GCM with a machine-derived key before writing to disk.### Changes:- `packages/config/src/crypto.ts` (new): Encryption/decryption using node:crypto- `packages/config/src/writer.ts`: Encrypts sensitive fields before save- `packages/config/src/loader.ts`: Decrypts on read- Backward compatible with existing plaintext configs