### PR TITLE
Reduce Startup time for Dev

### DIFF
--- a/packages/neo4j/src/conceptGraphIndexes.ts
+++ b/packages/neo4j/src/conceptGraphIndexes.ts
@@ -22,16 +22,22 @@ const FULLTEXT_INDEXES = [
 ];
 
 export async function ensureConceptGraphIndexes(): Promise<void> {
-  for (const cypher of [...CONSTRAINTS, ...FULLTEXT_INDEXES]) {
-    try {
-      await _runCypher(cypher);
-    } catch (cause: unknown) {
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
-        process.stderr.write(`[neo4j] concept-graph schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
-        continue;
-      }
-      throw cause;
+  const results = await Promise.allSettled(
+    [...CONSTRAINTS, ...FULLTEXT_INDEXES].map((cypher) =>
+      _runCypher(cypher).catch((cause: unknown) => {
+        const msg = cause instanceof Error ? cause.message : String(cause);
+        if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
+          process.stderr.write(`[neo4j] concept-graph schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
+          return;
+        }
+        throw cause;
+      }),
+    ),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
     }
   }
 }

--- a/packages/neo4j/src/flatFolderIndexes.ts
+++ b/packages/neo4j/src/flatFolderIndexes.ts
@@ -23,16 +23,22 @@ const FULLTEXT_INDEXES = [
 ];
 
 export async function ensureFlatFolderIndexes(): Promise<void> {
-  for (const cypher of [...CONSTRAINTS, ...FULLTEXT_INDEXES]) {
-    try {
-      await _runCypher(cypher);
-    } catch (cause: unknown) {
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
-        process.stderr.write(`[neo4j] flat-folder schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
-        continue;
-      }
-      throw cause;
+  const results = await Promise.allSettled(
+    [...CONSTRAINTS, ...FULLTEXT_INDEXES].map((cypher) =>
+      _runCypher(cypher).catch((cause: unknown) => {
+        const msg = cause instanceof Error ? cause.message : String(cause);
+        if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
+          process.stderr.write(`[neo4j] flat-folder schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
+          return;
+        }
+        throw cause;
+      }),
+    ),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
     }
   }
 }

--- a/packages/neo4j/src/indexes.ts
+++ b/packages/neo4j/src/indexes.ts
@@ -18,16 +18,22 @@ const FULLTEXT_INDEXES = [
 ];
 
 export async function ensureKnowledgeIndexes(): Promise<void> {
-  for (const cypher of [...CONSTRAINTS, ...FULLTEXT_INDEXES]) {
-    try {
-      await _runCypher(cypher);
-    } catch (cause: unknown) {
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
-        process.stderr.write(`[neo4j] schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
-        continue;
-      }
-      throw cause;
+  const results = await Promise.allSettled(
+    [...CONSTRAINTS, ...FULLTEXT_INDEXES].map((cypher) =>
+      _runCypher(cypher).catch((cause: unknown) => {
+        const msg = cause instanceof Error ? cause.message : String(cause);
+        if (msg.includes("already exists") || msg.includes("EquivalentSchemaRuleAlreadyExists")) {
+          process.stderr.write(`[neo4j] schema already present, skipping: ${cypher.slice(0, 60)}…\n`);
+          return;
+        }
+        throw cause;
+      }),
+    ),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
     }
   }
 }


### PR DESCRIPTION
**What changed**
Replaced sequential for...of loops with Promise.allSettled() across all 3 Neo4j index functions. All CREATE ... IF NOT EXISTS Cypher statements are safe to parallelize — duplicate existence errors are caught per-statement and non-fatal failures are re-thrown after collecting all results.

**Test**
From ingestion-engine, run bun run knowledge-server or bun run admin-server and confirm Neo4j constraints/indexes are created without errors